### PR TITLE
chore(release): v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-27
+
+First tagged release. Consolidates deployment and operations documentation and hardens
+JWT secret validation. No product features and no database migrations.
+
+### Added
+
+- Canonical deployment guide (`DEPLOYMENT.md`): production topology, required backend
+  environment variables, secret injection ownership, pre-deploy and post-deploy checklists,
+  rollback procedure and troubleshooting.
+- Security policy (`.github/SECURITY.md`) documenting the secret lifecycle.
+- GitHub workflow coordinates (`.claude/gh-project.md`): project board ids, branch model,
+  labels, pre-PR validation command and release pre-flight.
+- Draft migration plan for consolidating on Vercel and Supabase
+  (`docs/20260713_VERCEL_SUPABASE_MIGRATION_PLAN.md`).
+
+### Changed
+
+- **`JWT_SECRET` now requires a minimum length of 32 characters.** The backend fails to start
+  if the configured secret is shorter — verify the production value before deploying.
+- `CLAUDE.md`: corrected feature list, routes and API modules; removed a duplicate heading;
+  the GitHub section now points to the workflow skill instead of restating it.
+- Backend and frontend READMEs refreshed and aligned with the deployment guide.
+- `docs/PRODUCTION_RELEASE_AUTOMATION.md` and the Neon/Render runbook reduced to pointers to
+  the canonical deployment guide.
+
+### Removed
+
+- Outdated GitHub Actions workflows: `backend-tests.yml` and `release-to-prod.yml`.
+
+[0.1.0]: https://github.com/MrClit/friends-web/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "friends-monorepo",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "$schema": "https://json.schemastore.org/package.json",
   "type": "module",
   "packageManager": "pnpm@10.30.1",


### PR DESCRIPTION
## Qué problema resuelve

El repo no tiene ningún release etiquetado y el manifiesto raíz sigue en `0.0.0`, así que no hay forma de referirse a lo que hay en producción. Este PR corta la primera versión.

## Cambios

| Fichero | Cambio |
|---|---|
| `package.json` | versión `0.0.0` → `0.1.0` |
| `CHANGELOG.md` | nuevo, con la entrada de `0.1.0` en formato Keep a Changelog |

## Verificación

- `pnpm lint && pnpm test && pnpm build` en verde (224 tests de frontend, 21 suites de backend, build OK).
- Sin migraciones nuevas y sin cambios de producto en el release.