### PR TITLE
chore(release): v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-07-27
+
+Documentation only. Resolves contradictions between the deployment guide and the release
+workflow that would have desynced published tags from what is actually deployed.
+
+### Changed
+
+- `DEPLOYMENT.md` §3: the canonical release flow is now the documented choreography — version
+  bump, `CHANGELOG.md` entry, PR into `develop`, PR to `main` with a merge commit, annotated tag
+  and GitHub Release. `pnpm release:prod` is demoted to an emergency shortcut, with an explicit
+  warning that it skips versioning entirely and writes straight to `main` with no PR.
+- `DEPLOYMENT.md` §12: documentation policy now splits jurisdiction. Previously both this guide
+  and `.claude/gh-project.md` claimed precedence on conflict, leaving no tie-break.
+- `DEPLOYMENT.md` §8: notes that migrations run on backend startup (`start:prod:migrate`), after
+  the push to `main` triggers the Render redeploy — so they are verified before merging, not
+  applied earlier.
+- `.claude/gh-project.md`: references the pre-deploy checklist instead of duplicating it, and
+  records the migration-timing exception to the generic release rule.
+
+### Removed
+
+- `DEPLOYMENT.md` §3: the "Release to Production" GitHub Actions option. That workflow was
+  deleted in d912419 and shipped in 0.1.0, so the instruction pointed at nothing.
+
 ## [0.1.0] - 2026-07-27
 
 First tagged release. Consolidates deployment and operations documentation and hardens
@@ -35,4 +59,5 @@ JWT secret validation. No product features and no database migrations.
 
 - Outdated GitHub Actions workflows: `backend-tests.yml` and `release-to-prod.yml`.
 
+[0.1.1]: https://github.com/MrClit/friends-web/releases/tag/v0.1.1
 [0.1.0]: https://github.com/MrClit/friends-web/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "friends-monorepo",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "$schema": "https://json.schemastore.org/package.json",
   "type": "module",
   "packageManager": "pnpm@10.30.1",


### PR DESCRIPTION
## Qué problema resuelve

`DEPLOYMENT.md` recomendaba `pnpm release:prod`, que mergea `develop` en `main` en local y pushea sin PR, sin bump, sin CHANGELOG y sin tag. Seguirlo habría desincronizado los tags de lo que está desplegado, en silencio. El release v0.1.1 lleva a producción la documentación ya corregida.

## Cambios

| Fichero | Cambio |
|---|---|
| `package.json` | versión `0.1.0` → `0.1.1` |
| `CHANGELOG.md` | entrada `0.1.1` |

## Verificación

- `pnpm lint && pnpm test && pnpm build` en verde (224 tests de frontend, 21 suites de backend, build OK).
- Release de solo documentación: sin cambios de código de aplicación, sin migraciones y sin cambios de env vars.