### PR TITLE
Release v0.1.1

### DIFF
--- a/.claude/gh-project.md
+++ b/.claude/gh-project.md
@@ -96,15 +96,17 @@ la coreografía vía PR; usar el script solo si el usuario lo pide.
 
 ### Pre-vuelo del release
 
-De [`DEPLOYMENT.md`](../DEPLOYMENT.md) §8. Lo que depende de un panel externo lo verifica **el usuario**:
-
 - [ ] `pnpm lint && pnpm test && pnpm build` en verde en local sobre `develop`
-- [ ] `main` contendrá los ficheros de migración necesarios
-- [ ] Las migraciones nuevas compilan y no se han editado tras aplicarse en un entorno persistente
-- [ ] **Migraciones de base de datos aplicadas ANTES del merge a `main`**, no después
-- [ ] *(usuario)* Env vars de Render revisadas: DB, callbacks de OAuth, CORS, `FRONTEND_URL`
-- [ ] *(usuario)* Backup de base de datos si el release es arriesgado:
-      `pg_dump "$DATABASE_URL" -Fc -f backup_pre_release.dump`
+- [ ] Los checks de infraestructura de [`DEPLOYMENT.md`](../DEPLOYMENT.md) §8 — **es la lista
+      canónica, no la copies aquí**: migraciones, build del backend, env vars de Render, backup.
+- [ ] *(usuario)* Lo que dependa de un panel externo (Render, Neon, consolas de OAuth) lo verifica
+      **el usuario**, no el agente.
+
+> **Excepción a la regla genérica de la skill `release`.** La skill dice que las migraciones van
+> aplicadas antes del merge. Aquí **no se puede**: corren en el arranque del backend
+> (`start:prod:migrate` = `migration:run:prod && node dist/main`), o sea después de que el push a
+> `main` dispare el redeploy de Render. Lo que aplica aquí es **verificar** que la migración es
+> correcta y reversible antes de mergear; una que falle deja la API caída.
 
 Post-deploy: checklist de validación en `DEPLOYMENT.md` §9. Rollback: §10.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-07-27
+
+Documentation only. Resolves contradictions between the deployment guide and the release
+workflow that would have desynced published tags from what is actually deployed.
+
+### Changed
+
+- `DEPLOYMENT.md` §3: the canonical release flow is now the documented choreography — version
+  bump, `CHANGELOG.md` entry, PR into `develop`, PR to `main` with a merge commit, annotated tag
+  and GitHub Release. `pnpm release:prod` is demoted to an emergency shortcut, with an explicit
+  warning that it skips versioning entirely and writes straight to `main` with no PR.
+- `DEPLOYMENT.md` §12: documentation policy now splits jurisdiction. Previously both this guide
+  and `.claude/gh-project.md` claimed precedence on conflict, leaving no tie-break.
+- `DEPLOYMENT.md` §8: notes that migrations run on backend startup (`start:prod:migrate`), after
+  the push to `main` triggers the Render redeploy — so they are verified before merging, not
+  applied earlier.
+- `.claude/gh-project.md`: references the pre-deploy checklist instead of duplicating it, and
+  records the migration-timing exception to the generic release rule.
+
+### Removed
+
+- `DEPLOYMENT.md` §3: the "Release to Production" GitHub Actions option. That workflow was
+  deleted in d912419 and shipped in 0.1.0, so the instruction pointed at nothing.
+
 ## [0.1.0] - 2026-07-27
 
 First tagged release. Consolidates deployment and operations documentation and hardens
@@ -35,4 +59,5 @@ JWT secret validation. No product features and no database migrations.
 
 - Outdated GitHub Actions workflows: `backend-tests.yml` and `release-to-prod.yml`.
 
+[0.1.1]: https://github.com/MrClit/friends-web/releases/tag/v0.1.1
 [0.1.0]: https://github.com/MrClit/friends-web/releases/tag/v0.1.0

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,7 +2,8 @@
 
 Canonical deployment runbook for the Friends monorepo.
 
-This document is the single source of truth for production deployment and operations.
+This document is the single source of truth for **infrastructure and production operations**. The
+release *sequence* is not owned here — see §3.
 
 ## 1. Production Topology
 
@@ -13,8 +14,8 @@ This document is the single source of truth for production deployment and operat
 
 ## 2. Canonical Sources in This Repository
 
-- Release command: `pnpm release:prod` in root `package.json`
-- Release automation script: `scripts/release-to-prod.mjs`
+- Release coordinates (branches, board, pre-flight): `.claude/gh-project.md`
+- Emergency release shortcut: `pnpm release:prod` / `scripts/release-to-prod.mjs` (see §3)
 - Frontend deployment workflow: `.github/workflows/deploy.yml`
 - Backend production start and migrations: `apps/backend/package.json`
 - Backend env validation schema: `apps/backend/src/config/env.validation.ts`
@@ -23,27 +24,31 @@ This document is the single source of truth for production deployment and operat
 
 ## 3. Release Flow (Develop -> Main)
 
-### Option A: Local command (recommended)
+The canonical procedure lives in the `release` skill, which reads this repo's coordinates from
+[`.claude/gh-project.md`](.claude/gh-project.md). Follow that flow, not an ad-hoc merge.
 
-Run from monorepo root:
+In summary:
+
+1. Bump the root `package.json` and add the `CHANGELOG.md` entry on a `release/vX.Y.Z` branch
+2. Run the project validations, then open a PR into `develop` and **squash** merge it
+3. Open a PR `develop` -> `main` and merge it with a **merge commit** (preserves history)
+4. Annotated tag `vX.Y.Z` on `main`, plus a GitHub Release
+
+Versioning is SemVer over the root `package.json`; the packages under `apps/` and `packages/` stay
+at `0.0.0`.
+
+### Emergency shortcut: `pnpm release:prod`
 
 ```bash
 pnpm release:prod
 ```
 
-What it does:
+Merges `develop` into `main` locally and pushes it. **It skips versioning entirely** — no version
+bump, no `CHANGELOG.md` entry, no tag, no GitHub Release — and it writes straight to the production
+branch with no PR.
 
-1. Validates clean git working tree
-2. Fetches origin
-3. Checks out `main`
-4. Pulls latest `main`
-5. Merges `develop` into `main`
-6. Pushes `main` to origin
-7. Returns to the original branch
-
-### Option B: GitHub Actions manual workflow
-
-Run workflow `Release to Production` from GitHub Actions UI.
+Use it only when the normal flow is unavailable, and reconcile the version afterwards. Otherwise the
+tags stop matching what is deployed, silently.
 
 ## 4. Frontend Deployment (GitHub Pages)
 
@@ -161,11 +166,18 @@ Follow `.github/SECURITY.md` as the canonical policy for generation, rotation ca
 
 ## 8. Pre-Deploy Checklist
 
+Infrastructure checks. The release flow reads its pre-flight from
+[`.claude/gh-project.md`](.claude/gh-project.md), which points here — keep the list in one place.
+
 - `main` contains required migration files
 - Backend build is green
-- New migrations compile and are not edited after being applied in persistent environments
+- New migrations compile, are reversible, and are not edited after being applied in persistent environments
 - Render env vars reviewed (DB, OAuth callback URLs, CORS, frontend redirect URL)
 - Database backup generated before risky releases
+
+> Migrations run **on backend startup** (`start:prod:migrate`), which happens after `main` is pushed
+> and Render redeploys — there is no pre-merge migration step. A migration that fails takes the API
+> down with it, so it has to be verified *before* merging, not applied earlier.
 
 Recommended backup command:
 
@@ -238,6 +250,10 @@ Resolve conflicts in `develop`, then retry release.
 
 ## 12. Documentation Policy
 
-- This file is canonical for deployment operations.
+- This file is canonical for **infrastructure and production operations**: topology, environment
+  variables, Render and Pages configuration, rollback and smoke checks. If those instructions
+  conflict with any other document, this file takes precedence.
+- The **release sequence** is not owned here. It belongs to the `release` skill, with this repo's
+  coordinates in `.claude/gh-project.md`. If the two disagree about *how a release is cut*, the
+  skill wins; if they disagree about *how production is configured*, this file wins.
 - Files under `docs/` may contain planning notes or historical snapshots.
-- If deployment instructions conflict, this file takes precedence.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "friends-monorepo",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "$schema": "https://json.schemastore.org/package.json",
   "type": "module",
   "packageManager": "pnpm@10.30.1",


### PR DESCRIPTION
⚠️ Este merge dispara el deploy a producción (GitHub Pages + Render).

## [0.1.1] - 2026-07-27

Documentation only. Resolves contradictions between the deployment guide and the release
workflow that would have desynced published tags from what is actually deployed.

### Changed

- `DEPLOYMENT.md` §3: the canonical release flow is now the documented choreography — version
  bump, `CHANGELOG.md` entry, PR into `develop`, PR to `main` with a merge commit, annotated tag
  and GitHub Release. `pnpm release:prod` is demoted to an emergency shortcut, with an explicit
  warning that it skips versioning entirely and writes straight to `main` with no PR.
- `DEPLOYMENT.md` §12: documentation policy now splits jurisdiction. Previously both this guide
  and `.claude/gh-project.md` claimed precedence on conflict, leaving no tie-break.
- `DEPLOYMENT.md` §8: notes that migrations run on backend startup (`start:prod:migrate`), after
  the push to `main` triggers the Render redeploy — so they are verified before merging, not
  applied earlier.
- `.claude/gh-project.md`: references the pre-deploy checklist instead of duplicating it, and
  records the migration-timing exception to the generic release rule.

### Removed

- `DEPLOYMENT.md` §3: the "Release to Production" GitHub Actions option. That workflow was
  deleted in d912419 and shipped in 0.1.0, so the instruction pointed at nothing.