### PR TITLE
chore(ci): run lint, tests and build on pull requests (#76)

### DIFF
--- a/.claude/gh-project.md
+++ b/.claude/gh-project.md
@@ -73,11 +73,16 @@ la descripción va en castellano (p. ej. `fix(a11y): añadir enlace de salto a l
 pnpm lint && pnpm test && pnpm build
 ```
 
-Cubre frontend, backend y `shared-types`. La CI (`deploy.yml`) solo valida el frontend, así que
-**este comando es más estricto que la CI a propósito**: es lo que evita romper el backend.
+Cubre frontend, backend y `shared-types`. `.github/workflows/ci.yml` corre lo mismo en cada PR hacia
+`develop` o `main` (job `quality`: lint + tests del frontend + build; job `backend`: las tres suites
+contra un Postgres de CI), pero ejecutarlo en local antes de abrir el PR sigue siendo lo que evita
+el ciclo push–esperar–arreglar.
 
 Los tests del backend que necesitan PostgreSQL requieren la base levantada:
-`cd apps/backend && docker-compose up -d`.
+`cd apps/backend && docker-compose up -d`, y un `apps/backend/.env.test` (no commiteado) copiado de
+`.env.test.example`.
+
+Ambos checks son **requeridos** en `develop` y `main`; `main` exige además PR.
 
 Nunca `--no-verify`.
 
@@ -91,9 +96,9 @@ deben coincidir. Consúltalos (`git tag -l`, `gh release list`) en vez de fiarte
 
 `CHANGELOG.md` existe en la raíz y se actualiza en el commit de bump (`chore(release): vX.Y.Z`).
 
-Alternativa scriptada al paso «PR de integración a producción»: `pnpm release:prod`
-(`scripts/release-to-prod.mjs`) hace el merge `develop` → `main` en local. La skill `release` prefiere
-la coreografía vía PR; usar el script solo si el usuario lo pide.
+> `pnpm release:prod` (`scripts/release-to-prod.mjs`) mergeaba `develop` → `main` en local y hacía
+> push directo. **Ya no sirve**: `main` exige PR y checks en verde, así que el push se rechaza. La
+> única vía es la coreografía por PR de la skill `release`.
 
 ### Pre-vuelo del release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,111 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop # post-merge signal; pushes to main are covered by deploy.yml
+
+# A new push to the same branch makes the previous run obsolete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PNPM_VERSION: 10.30.1
+  NODE_VERSION: '24'
+
+jobs:
+  quality:
+    name: Lint, frontend tests and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run linter
+        run: pnpm lint # includes check:skills
+
+      - name: Build all packages
+        run: pnpm build # shared-types + frontend (tsc -b) + backend (nest build)
+
+      - name: Run frontend tests
+        run: pnpm --filter @friends/frontend test:run
+
+  backend:
+    name: Backend tests (unit, integration, e2e)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: friends_db_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The committed dist could lag behind the sources; the backend imports it at runtime.
+      - name: Build shared-types
+        run: pnpm --filter @friends/shared-types build
+
+      # .env.test is gitignored: the example is the source of truth for the test config.
+      - name: Create test environment file
+        run: cp .env.test.example .env.test
+        working-directory: apps/backend
+
+      - name: Run unit tests
+        run: pnpm --filter @friends/backend test:run
+
+      # TYPEORM_SYNC=true creates the schema, so no migrations are needed here.
+      - name: Run integration tests
+        run: pnpm --filter @friends/backend test:int
+
+      - name: Run e2e tests
+        run: pnpm --filter @friends/backend test:e2e

--- a/apps/backend/.env.test.example
+++ b/apps/backend/.env.test.example
@@ -1,6 +1,8 @@
 # Server
 PORT=3001
 NODE_ENV=test
+# Tests assert on responses, not on logs: keep the output readable in CI.
+LOG_LEVEL=silent
 
 # Database
 DATABASE_HOST=localhost
@@ -17,8 +19,8 @@ TYPEORM_LOGGING=false
 # CORS
 CORS_ORIGIN=http://localhost:5173
 
-# JWT
-JWT_SECRET=test-secret-key
+# JWT — envValidationSchema requires at least 32 characters.
+JWT_SECRET=test-only-secret-not-a-real-key-32chars
 JWT_EXPIRATION=15m
 REFRESH_TOKEN_EXPIRATION_DAYS=30
 


### PR DESCRIPTION
Relacionado con #76 (no autocierra: `develop` no es la rama por defecto del repo).

## Qué problema resuelve

El único workflow del repo, `deploy.yml`, se dispara exclusivamente en `push` a `main`. No existe ningún trigger `pull_request`, así que ningún PR recibe validación automática antes de mergearse: el primer indicio de un lint, un test o un build rotos es un deploy a producción en rojo. Esto se confirmó durante el release de v0.1.0, donde `gh pr checks --watch` devolvió "no checks reported" en dos PRs seguidos.

## Cambios

- **`.github/workflows/ci.yml` (nuevo)** — workflow `CI` con trigger `pull_request` sobre `develop` y `main`, más `push` sobre `develop`. Dos jobs:
  - `quality`: lint (incluye `check:skills`), build del monorepo, tests del frontend.
  - `backend`: las tres suites de backend (`test:run`, `test:int`, `test:e2e`) contra un service container `postgres:17-alpine`.
  Ambos con `timeout-minutes: 15` y `concurrency` con `cancel-in-progress`.
- **`apps/backend/.env.test.example`** — bloqueante encontrado al preparar este workflow: el `JWT_SECRET` de ejemplo tenía 15 caracteres, pero el schema de validación de entorno exige un mínimo de 32. Con el valor anterior, cualquiera que copiase el ejemplo a `.env.test` (incluida la propia CI) veía reventar las suites de integración y e2e al arrancar con "Config validation error", antes de correr un solo test. Se aprovecha también para añadir `LOG_LEVEL=silent` y mantener limpia la salida en CI.
- **`.claude/gh-project.md`** — la sección de validaciones ya no dice que la CI solo cubre el frontend, y se anota que `pnpm release:prod` deja de servir en cuanto `main` exija PR y checks (la única vía pasa a ser la coreografía por PR de la skill `release`).

`deploy.yml` se queda intacto: sigue disparándose solo en `push` a `main`, no en eventos de PR.

## Verificación

- En local, sobre `develop`, con los cambios: `pnpm lint`, `pnpm build`, tests de frontend y las tres suites de backend, todo en verde.
- Pendiente (se reportará en este PR): resultado de `gh pr checks --watch`, la primera vez que corren los checks nuevos de verdad en CI.

## Pendiente fuera de este PR

Añadir los checks no los hace obligatorios por sí solo. Falta, como paso posterior y manual:
- Marcar `quality` y `backend` como checks requeridos en `develop` y `main` mediante ruleset.
- Exigir PR obligatorio en `main`.

Sin ese paso, los checks quedan en modo informativo y un PR que los rompa se puede mergear igualmente.
