### PR TITLE
fix(backend,frontend): sustituir el refresh token de la URL del callback OAuth por un código de intercambio de un solo uso

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -28,6 +28,8 @@ CORS_ORIGIN=http://localhost:5173
 JWT_SECRET=replace-with-secure-random
 JWT_EXPIRATION=15m
 REFRESH_TOKEN_EXPIRATION_DAYS=30
+# One-time OAuth callback exchange code lifetime (seconds)
+AUTH_EXCHANGE_CODE_TTL_SECONDS=60
 
 # Google OAuth2
 GOOGLE_CLIENT_ID=replace-with-google-client-id

--- a/apps/backend/.env.test.example
+++ b/apps/backend/.env.test.example
@@ -23,6 +23,7 @@ CORS_ORIGIN=http://localhost:5173
 JWT_SECRET=test-only-secret-not-a-real-key-32chars
 JWT_EXPIRATION=15m
 REFRESH_TOKEN_EXPIRATION_DAYS=30
+AUTH_EXCHANGE_CODE_TTL_SECONDS=60
 
 # Google OAuth2 (not required for e2e auth smoke tests)
 GOOGLE_CLIENT_ID=test-client-id

--- a/apps/backend/src/config/env.validation.ts
+++ b/apps/backend/src/config/env.validation.ts
@@ -38,4 +38,5 @@ export const envValidationSchema = Joi.object({
 
   REFRESH_TOKEN_EXPIRATION_DAYS: Joi.number().integer().default(30),
   REFRESH_TOKEN_MAX_ROTATIONS: Joi.number().integer().min(1).default(100),
+  AUTH_EXCHANGE_CODE_TTL_SECONDS: Joi.number().integer().min(10).default(60),
 });

--- a/apps/backend/src/migrations/1705700000000-CreateAuthExchangeCodesTable.ts
+++ b/apps/backend/src/migrations/1705700000000-CreateAuthExchangeCodesTable.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAuthExchangeCodesTable1705700000000 implements MigrationInterface {
+  name = 'CreateAuthExchangeCodesTable1705700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS auth_exchange_codes (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        code_hash varchar NOT NULL,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        expires_at timestamptz NOT NULL,
+        consumed_at timestamptz,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_exchange_codes_code_hash
+      ON auth_exchange_codes (code_hash);
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_auth_exchange_codes_user_id
+      ON auth_exchange_codes (user_id);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS auth_exchange_codes;`);
+  }
+}

--- a/apps/backend/src/modules/auth/README.md
+++ b/apps/backend/src/modules/auth/README.md
@@ -24,6 +24,8 @@ El módulo `auth` gestiona la autenticación y autorización de usuarios en la A
 - **services/**:
   - **oauth-provider.service.ts**: Lógica común de validación/login OAuth para proveedores.
   - **avatar.service.ts**: Gestión de avatares en Cloudinary.
+  - **refresh-token.service.ts**: Emisión, rotación y revocación de refresh tokens (hash SHA-256, familias, detección de brechas).
+  - **auth-exchange-code.service.ts**: Códigos de intercambio de un solo uso (TTL corto) para el callback OAuth.
 - **strategies/**:
   - **index.ts**: Registro centralizado de estrategias (`AUTH_STRATEGIES`).
   - **jwt/jwt.strategy.ts**: Validación JWT para rutas protegidas.
@@ -41,8 +43,12 @@ El módulo `auth` gestiona la autenticación y autorización de usuarios en la A
 1. El usuario accede a `/auth/google` o `/auth/microsoft` para iniciar sesión con su proveedor.
 2. El proveedor OAuth redirige al backend con el código de autorización.
 3. `google.strategy.ts` o `microsoft.strategy.ts` validan el perfil y delegan en `auth.service.ts`.
-4. `auth.controller.ts` genera un JWT y redirige al frontend a `/auth/callback` con el token.
-5. Las rutas protegidas usan `jwt.strategy.ts` para validar el token.
+4. `auth.controller.ts` emite un **código de intercambio de un solo uso** (TTL configurable vía
+   `AUTH_EXCHANGE_CODE_TTL_SECONDS`, 60 s por defecto) y redirige al frontend a `/auth/callback?code=…`.
+   Ningún token viaja en la URL.
+5. El frontend canjea el código vía `POST /auth/exchange` y recibe el par `accessToken` + `refreshToken`.
+6. `POST /auth/refresh` rota el refresh token; `POST /auth/logout` lo revoca.
+7. Las rutas protegidas usan `jwt.strategy.ts` para validar el access token.
 
 ## 4. Estrategias de Autenticación
 

--- a/apps/backend/src/modules/auth/auth.controller.spec.ts
+++ b/apps/backend/src/modules/auth/auth.controller.spec.ts
@@ -1,7 +1,9 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { AuthController } from './auth.controller';
 import type { AuthService } from './auth.service';
 import type { UsersService } from '../users/users.service';
 import type { ConfigService } from '@nestjs/config';
+import type { AuthExchangeCodeService } from './services/auth-exchange-code.service';
 import type { User } from '../users/user.entity';
 import type { Response } from 'express';
 
@@ -15,6 +17,7 @@ describe('AuthController', () => {
   };
   let usersService: { toCurrentUserProfile: jest.Mock; findByIdOrThrow: jest.Mock };
   let configService: { get: jest.Mock };
+  let authExchangeCodeService: { issueCode: jest.Mock; consumeCode: jest.Mock };
 
   const baseUser: User = {
     id: 'user-1',
@@ -47,37 +50,81 @@ describe('AuthController', () => {
       get: jest.fn().mockReturnValue('http://localhost:5173/friends-web/#'),
     };
 
+    authExchangeCodeService = {
+      issueCode: jest.fn().mockResolvedValue({ rawCode: 'exchange-code' }),
+      consumeCode: jest.fn(),
+    };
+
     controller = new AuthController(
       authService as unknown as AuthService,
       usersService as unknown as UsersService,
       configService as unknown as ConfigService,
+      authExchangeCodeService as unknown as AuthExchangeCodeService,
     );
   });
 
-  it('redirects Google callback to frontend with success flag and refresh token in query param', async () => {
+  it('redirects Google callback to frontend with success flag and one-time code, never a refresh token', async () => {
     const req = { user: baseUser } as Parameters<typeof controller.googleAuthRedirect>[0];
     const redirect = jest.fn();
     const res = { redirect } as unknown as Response;
 
     await controller.googleAuthRedirect(req, res);
 
-    expect(authService.generateAuthTokens).toHaveBeenCalledWith(baseUser);
+    expect(authExchangeCodeService.issueCode).toHaveBeenCalledWith(baseUser.id);
+    expect(authService.generateAuthTokens).not.toHaveBeenCalled();
     expect(redirect).toHaveBeenCalledTimes(1);
     expect(redirect).toHaveBeenCalledWith(expect.stringContaining('/auth/callback?success=true'));
-    expect(redirect).toHaveBeenCalledWith(expect.stringContaining('refreshToken='));
+    expect(redirect).toHaveBeenCalledWith(expect.stringContaining('code=exchange-code'));
+    expect(redirect).not.toHaveBeenCalledWith(expect.stringContaining('refreshToken='));
   });
 
-  it('redirects Microsoft callback to frontend with success flag and refresh token in query param', async () => {
+  it('redirects Microsoft callback to frontend with success flag and one-time code, never a refresh token', async () => {
     const req = { user: baseUser } as Parameters<typeof controller.microsoftAuthRedirect>[0];
     const redirect = jest.fn();
     const res = { redirect } as unknown as Response;
 
     await controller.microsoftAuthRedirect(req, res);
 
-    expect(authService.generateAuthTokens).toHaveBeenCalledWith(baseUser);
+    expect(authExchangeCodeService.issueCode).toHaveBeenCalledWith(baseUser.id);
+    expect(authService.generateAuthTokens).not.toHaveBeenCalled();
     expect(redirect).toHaveBeenCalledTimes(1);
     expect(redirect).toHaveBeenCalledWith(expect.stringContaining('/auth/callback?success=true'));
-    expect(redirect).toHaveBeenCalledWith(expect.stringContaining('refreshToken='));
+    expect(redirect).toHaveBeenCalledWith(expect.stringContaining('code=exchange-code'));
+    expect(redirect).not.toHaveBeenCalledWith(expect.stringContaining('refreshToken='));
+  });
+
+  it('exchange consumes the code and returns the token pair', async () => {
+    const json = jest.fn();
+    const res = { json } as unknown as Response;
+
+    authExchangeCodeService.consumeCode.mockResolvedValue('user-1');
+    usersService.findByIdOrThrow.mockResolvedValue(baseUser);
+
+    await controller.exchange({ code: 'exchange-code' }, res);
+
+    expect(authExchangeCodeService.consumeCode).toHaveBeenCalledWith('exchange-code');
+    expect(usersService.findByIdOrThrow).toHaveBeenCalledWith('user-1');
+    expect(authService.generateAuthTokens).toHaveBeenCalledWith(baseUser);
+    expect(json).toHaveBeenCalledWith({ data: { accessToken: 'jwt-token', refreshToken: 'refresh-token' } });
+  });
+
+  it('exchange rejects an invalid code with UnauthorizedException', async () => {
+    const res = { json: jest.fn() } as unknown as Response;
+
+    authExchangeCodeService.consumeCode.mockRejectedValue(new UnauthorizedException());
+
+    await expect(controller.exchange({ code: 'bad-code' }, res)).rejects.toThrow(UnauthorizedException);
+    expect(authService.generateAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it('exchange rejects when the code owner no longer exists', async () => {
+    const res = { json: jest.fn() } as unknown as Response;
+
+    authExchangeCodeService.consumeCode.mockResolvedValue('user-gone');
+    usersService.findByIdOrThrow.mockRejectedValue(new Error('not found'));
+
+    await expect(controller.exchange({ code: 'exchange-code' }, res)).rejects.toThrow(UnauthorizedException);
+    expect(authService.generateAuthTokens).not.toHaveBeenCalled();
   });
 
   it('refresh rotates token and returns new access token and refresh token in body', async () => {

--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -4,9 +4,10 @@ import { AuthGuard } from '@nestjs/passport';
 import { ApiErrorResponseDto } from '../../common/dto/api-error-response.dto';
 import { ConfigService } from '@nestjs/config';
 import { Throttle } from '@nestjs/throttler';
-import { IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { ApiStandardResponse } from '../../common/decorators/api-standard-response.decorator';
 import { AuthService } from './auth.service';
+import { AuthExchangeCodeService } from './services/auth-exchange-code.service';
 import type { Request, Response } from 'express';
 import { CurrentUserProfileDto } from '../users/dto/current-user-profile.dto';
 import { User } from '../users/user.entity';
@@ -18,6 +19,12 @@ class RefreshTokenDto {
   refreshToken?: string;
 }
 
+class ExchangeCodeDto {
+  @IsString()
+  @IsNotEmpty()
+  code!: string;
+}
+
 @Throttle({ default: { ttl: 60_000, limit: 10 } })
 @ApiTags('Auth')
 @Controller('auth')
@@ -26,6 +33,7 @@ export class AuthController {
     private readonly authService: AuthService,
     private readonly usersService: UsersService,
     private readonly configService: ConfigService,
+    private readonly authExchangeCodeService: AuthExchangeCodeService,
   ) {}
 
   @Get('google')
@@ -37,7 +45,7 @@ export class AuthController {
   @Get('google/callback')
   @UseGuards(AuthGuard('google'))
   async googleAuthRedirect(@Req() req: Request & { user: User }, @Res() res: Response) {
-    return this.redirectToFrontendWithToken(req.user, res);
+    return this.redirectToFrontendWithCode(req.user, res);
   }
 
   @Get('microsoft')
@@ -49,10 +57,27 @@ export class AuthController {
   @Get('microsoft/callback')
   @UseGuards(AuthGuard('microsoft'))
   async microsoftAuthRedirect(@Req() req: Request & { user: User }, @Res() res: Response) {
-    return this.redirectToFrontendWithToken(req.user, res);
+    return this.redirectToFrontendWithCode(req.user, res);
+  }
+
+  @Post('exchange')
+  @Throttle({ default: { ttl: 60_000, limit: 5 } })
+  @ApiOperation({ summary: 'Exchange a one-time OAuth callback code for auth tokens' })
+  @ApiResponse({ status: 401, description: 'Invalid or expired exchange code', type: ApiErrorResponseDto })
+  async exchange(@Body() body: ExchangeCodeDto, @Res() res: Response) {
+    const userId = await this.authExchangeCodeService.consumeCode(body.code);
+    const user = await this.usersService.findByIdOrThrow(userId).catch(() => {
+      throw new UnauthorizedException();
+    });
+    const { accessToken, refreshToken } = await this.authService.generateAuthTokens(user);
+
+    return res.json({ data: { accessToken, refreshToken } });
   }
 
   @Post('refresh')
+  // Access tokens live only in memory, so every tab load triggers a refresh;
+  // keep this limit generous enough for several devices behind one NAT.
+  @Throttle({ default: { ttl: 60_000, limit: 30 } })
   @ApiOperation({ summary: 'Rotate refresh token and get new access token' })
   @ApiResponse({ status: 401, description: 'Invalid or expired refresh token', type: ApiErrorResponseDto })
   async refresh(@Body() body: RefreshTokenDto, @Res() res: Response) {
@@ -92,10 +117,10 @@ export class AuthController {
     return this.usersService.toCurrentUserProfile(req.user);
   }
 
-  private async redirectToFrontendWithToken(user: User, res: Response) {
-    const { refreshToken } = await this.authService.generateAuthTokens(user);
+  private async redirectToFrontendWithCode(user: User, res: Response) {
+    const { rawCode } = await this.authExchangeCodeService.issueCode(user.id);
     const frontendUrl = this.configService.get<string>('FRONTEND_URL', 'http://localhost:5173/friends-web/#');
-    const redirectUrl = `${frontendUrl}/auth/callback?success=true&refreshToken=${encodeURIComponent(refreshToken)}`;
+    const redirectUrl = `${frontendUrl}/auth/callback?success=true&code=${encodeURIComponent(rawCode)}`;
     return res.redirect(redirectUrl);
   }
 }

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -10,7 +10,9 @@ import { UsersModule } from '../users/users.module';
 import { AvatarService } from './services/avatar.service';
 import { OAuthProviderService } from './services/oauth-provider.service';
 import { RefreshTokenService } from './services/refresh-token.service';
+import { AuthExchangeCodeService } from './services/auth-exchange-code.service';
 import { RefreshToken } from './entities/refresh-token.entity';
+import { AuthExchangeCode } from './entities/auth-exchange-code.entity';
 import { AUTH_STRATEGIES } from './strategies';
 
 @Module({
@@ -18,7 +20,7 @@ import { AUTH_STRATEGIES } from './strategies';
     ConfigModule,
     UsersModule,
     PassportModule,
-    TypeOrmModule.forFeature([RefreshToken]),
+    TypeOrmModule.forFeature([RefreshToken, AuthExchangeCode]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: (config: ConfigService) => ({
@@ -28,7 +30,15 @@ import { AUTH_STRATEGIES } from './strategies';
       inject: [ConfigService],
     }),
   ],
-  providers: [AuthService, AvatarService, OAuthProviderService, RefreshTokenService, ...AUTH_STRATEGIES, RolesGuard],
+  providers: [
+    AuthService,
+    AvatarService,
+    OAuthProviderService,
+    RefreshTokenService,
+    AuthExchangeCodeService,
+    ...AUTH_STRATEGIES,
+    RolesGuard,
+  ],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/apps/backend/src/modules/auth/entities/auth-exchange-code.entity.ts
+++ b/apps/backend/src/modules/auth/entities/auth-exchange-code.entity.ts
@@ -1,0 +1,24 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('auth_exchange_codes')
+export class AuthExchangeCode {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index({ unique: true })
+  @Column({ name: 'code_hash', type: 'varchar' })
+  codeHash!: string;
+
+  @Index()
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId!: string;
+
+  @Column({ name: 'expires_at', type: 'timestamptz' })
+  expiresAt!: Date;
+
+  @Column({ name: 'consumed_at', type: 'timestamptz', nullable: true })
+  consumedAt!: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/apps/backend/src/modules/auth/services/auth-exchange-code.service.spec.ts
+++ b/apps/backend/src/modules/auth/services/auth-exchange-code.service.spec.ts
@@ -1,0 +1,120 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'crypto';
+import type { Repository } from 'typeorm';
+import { AuthExchangeCodeService } from './auth-exchange-code.service';
+import { AuthExchangeCode } from '../entities/auth-exchange-code.entity';
+
+const hashCode = (rawCode: string): string => createHash('sha256').update(rawCode).digest('hex');
+
+// `expect.any` is typed as `any`; this alias keeps the matcher usable inside object literals.
+const anyObject = expect.any(Object) as unknown as object;
+
+describe('AuthExchangeCodeService', () => {
+  let service: AuthExchangeCodeService;
+  let repository: {
+    create: jest.Mock;
+    save: jest.Mock;
+    delete: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let queryBuilder: {
+    update: jest.Mock;
+    set: jest.Mock;
+    where: jest.Mock;
+    returning: jest.Mock;
+    execute: jest.Mock;
+  };
+  let configService: { get: jest.Mock };
+  let savedCodes: AuthExchangeCode[];
+
+  beforeEach(() => {
+    savedCodes = [];
+
+    queryBuilder = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      returning: jest.fn().mockReturnThis(),
+      execute: jest.fn(),
+    };
+
+    repository = {
+      create: jest.fn((entity: AuthExchangeCode) => entity),
+      save: jest.fn().mockImplementation((entity: AuthExchangeCode) => {
+        savedCodes.push(entity);
+        return Promise.resolve(entity);
+      }),
+      delete: jest.fn().mockResolvedValue(undefined),
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+
+    configService = {
+      get: jest.fn().mockReturnValue('60'),
+    };
+
+    service = new AuthExchangeCodeService(
+      repository as unknown as Repository<AuthExchangeCode>,
+      configService as unknown as ConfigService,
+    );
+  });
+
+  it('issueCode stores the SHA-256 hash, never the raw code', async () => {
+    const { rawCode } = await service.issueCode('user-1');
+
+    expect(rawCode).toEqual(expect.any(String));
+    expect(rawCode.length).toBeGreaterThanOrEqual(64);
+
+    const saved = savedCodes[0];
+    expect(saved.codeHash).toBe(hashCode(rawCode));
+    expect(saved.codeHash).not.toBe(rawCode);
+    expect(saved.userId).toBe('user-1');
+  });
+
+  it('issueCode applies the configured TTL to expiresAt', async () => {
+    configService.get.mockReturnValue('120');
+    const before = Date.now();
+
+    await service.issueCode('user-1');
+
+    const saved = savedCodes[0];
+    const ttlMs = saved.expiresAt.getTime() - before;
+    expect(ttlMs).toBeGreaterThanOrEqual(119_000);
+    expect(ttlMs).toBeLessThanOrEqual(121_000);
+  });
+
+  it('issueCode falls back to 60 seconds when the TTL config is invalid', async () => {
+    configService.get.mockReturnValue('not-a-number');
+    const before = Date.now();
+
+    await service.issueCode('user-1');
+
+    const saved = savedCodes[0];
+    const ttlMs = saved.expiresAt.getTime() - before;
+    expect(ttlMs).toBeGreaterThanOrEqual(59_000);
+    expect(ttlMs).toBeLessThanOrEqual(61_000);
+  });
+
+  it('consumeCode returns the owning user id when the atomic update wins', async () => {
+    queryBuilder.execute.mockResolvedValue({ affected: 1, raw: [{ user_id: 'user-1' }] });
+
+    await expect(service.consumeCode('raw-code')).resolves.toBe('user-1');
+
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      'code_hash = :codeHash AND consumed_at IS NULL AND expires_at > NOW()',
+      { codeHash: hashCode('raw-code') },
+    );
+  });
+
+  it('consumeCode throws UnauthorizedException when no row is updated (unknown, expired or consumed)', async () => {
+    queryBuilder.execute.mockResolvedValue({ affected: 0, raw: [] });
+
+    await expect(service.consumeCode('raw-code')).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('deleteExpiredCodes deletes rows past their expiration', async () => {
+    await service.deleteExpiredCodes();
+
+    expect(repository.delete).toHaveBeenCalledWith({ expiresAt: anyObject });
+  });
+});

--- a/apps/backend/src/modules/auth/services/auth-exchange-code.service.ts
+++ b/apps/backend/src/modules/auth/services/auth-exchange-code.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { randomBytes, createHash } from 'crypto';
+import { Repository, LessThan } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { AuthExchangeCode } from '../entities/auth-exchange-code.entity';
+
+interface IssuedExchangeCode {
+  rawCode: string;
+}
+
+@Injectable()
+export class AuthExchangeCodeService {
+  constructor(
+    @InjectRepository(AuthExchangeCode)
+    private readonly exchangeCodeRepository: Repository<AuthExchangeCode>,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async issueCode(userId: string): Promise<IssuedExchangeCode> {
+    const rawCode = randomBytes(32).toString('hex');
+    const codeHash = this.hashCode(rawCode);
+
+    await this.exchangeCodeRepository.save(
+      this.exchangeCodeRepository.create({
+        codeHash,
+        userId,
+        expiresAt: this.getExpirationDate(),
+      }),
+    );
+
+    return { rawCode };
+  }
+
+  /**
+   * Consumes a one-time exchange code and returns the owning user id.
+   * The single-use guarantee is enforced atomically: a conditional UPDATE
+   * marks the code as consumed, so concurrent redemptions can never both win.
+   */
+  async consumeCode(rawCode: string): Promise<string> {
+    const codeHash = this.hashCode(rawCode);
+
+    const result = await this.exchangeCodeRepository
+      .createQueryBuilder()
+      .update(AuthExchangeCode)
+      .set({ consumedAt: new Date() })
+      .where('code_hash = :codeHash AND consumed_at IS NULL AND expires_at > NOW()', { codeHash })
+      .returning(['userId'])
+      .execute();
+
+    const consumed = (result.raw as { user_id: string }[])[0];
+    if (!result.affected || !consumed) {
+      throw new UnauthorizedException('Invalid or expired exchange code');
+    }
+
+    return consumed.user_id;
+  }
+
+  async deleteExpiredCodes(): Promise<void> {
+    await this.exchangeCodeRepository.delete({ expiresAt: LessThan(new Date()) });
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async cleanupExpiredCodes(): Promise<void> {
+    await this.deleteExpiredCodes();
+  }
+
+  private hashCode(rawCode: string): string {
+    return createHash('sha256').update(rawCode).digest('hex');
+  }
+
+  private getExpirationDate(): Date {
+    const configuredSeconds = Number(this.configService.get<string>('AUTH_EXCHANGE_CODE_TTL_SECONDS') ?? '60');
+    const seconds = Number.isFinite(configuredSeconds) && configuredSeconds > 0 ? configuredSeconds : 60;
+
+    return new Date(Date.now() + seconds * 1000);
+  }
+}

--- a/apps/backend/test/auth-access-control.int-spec.ts
+++ b/apps/backend/test/auth-access-control.int-spec.ts
@@ -184,13 +184,32 @@ describe('Auth access control (integration)', () => {
       await oauthApp.close();
     });
 
-    it('redirects to the frontend callback URL with success=true and a refreshToken', async () => {
+    it('redirects to the frontend callback URL with success=true and a one-time code, never a token', async () => {
       const httpServer = oauthApp.getHttpServer() as Parameters<typeof request>[0];
       const response = await request(httpServer).get('/api/auth/google/callback').expect(302);
 
       expect(response.headers.location).toContain('/auth/callback');
       expect(response.headers.location).toContain('success=true');
-      expect(response.headers.location).toContain('refreshToken=');
+      expect(response.headers.location).toContain('code=');
+      expect(response.headers.location).not.toContain('refreshToken=');
+    });
+
+    it('the code from the callback URL can be exchanged once for the token pair', async () => {
+      const httpServer = oauthApp.getHttpServer() as Parameters<typeof request>[0];
+      const redirectRes = await request(httpServer).get('/api/auth/google/callback').expect(302);
+
+      const location = String(redirectRes.headers.location);
+      const code = new URLSearchParams(location.split('?')[1]).get('code');
+      expect(code).toBeTruthy();
+
+      const exchangeRes = await request(httpServer).post('/api/auth/exchange').send({ code }).expect(201);
+
+      const body = exchangeRes.body as { data: { accessToken: string; refreshToken: string } };
+      expect(typeof body.data.accessToken).toBe('string');
+      expect(typeof body.data.refreshToken).toBe('string');
+
+      // Second redemption must fail: the code is single use
+      await request(httpServer).post('/api/auth/exchange').send({ code }).expect(401);
     });
   });
 });

--- a/apps/backend/test/auth-exchange-code.int-spec.ts
+++ b/apps/backend/test/auth-exchange-code.int-spec.ts
@@ -1,0 +1,124 @@
+import { INestApplication, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { createHash } from 'crypto';
+import { Repository } from 'typeorm';
+import { AppModule } from '../src/app.module';
+import { AuthExchangeCode } from '../src/modules/auth/entities/auth-exchange-code.entity';
+import { AuthExchangeCodeService } from '../src/modules/auth/services/auth-exchange-code.service';
+import { User } from '../src/modules/users/user.entity';
+import { createUser } from './utils/test-factories';
+
+const hashCode = (rawCode: string): string => createHash('sha256').update(rawCode).digest('hex');
+
+describe('AuthExchangeCodeService (integration)', () => {
+  let app: INestApplication;
+  let exchangeCodeService: AuthExchangeCodeService;
+  let exchangeCodeRepository: Repository<AuthExchangeCode>;
+  let userRepository: Repository<User>;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    exchangeCodeService = app.get(AuthExchangeCodeService);
+    exchangeCodeRepository = app.get<Repository<AuthExchangeCode>>(getRepositoryToken(AuthExchangeCode));
+    userRepository = app.get<Repository<User>>(getRepositoryToken(User));
+  });
+
+  beforeEach(async () => {
+    await exchangeCodeRepository.createQueryBuilder().delete().from(AuthExchangeCode).execute();
+    await userRepository.createQueryBuilder().delete().from(User).execute();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('issueCode: stores SHA-256 hash, not the raw code', async () => {
+    const user = await createUser(userRepository, { email: 'hash@test.com', name: 'Hash User' });
+    const { rawCode } = await exchangeCodeService.issueCode(user.id);
+
+    const record = await exchangeCodeRepository.findOne({ where: { userId: user.id } });
+
+    expect(record).not.toBeNull();
+    expect(record!.codeHash).toBe(hashCode(rawCode));
+    expect(record!.codeHash).not.toBe(rawCode);
+    expect(record!.consumedAt).toBeNull();
+  });
+
+  it('consumeCode: returns the user id and marks the code as consumed', async () => {
+    const user = await createUser(userRepository, { email: 'consume@test.com', name: 'Consume User' });
+    const { rawCode } = await exchangeCodeService.issueCode(user.id);
+
+    const userId = await exchangeCodeService.consumeCode(rawCode);
+
+    expect(userId).toBe(user.id);
+    const record = await exchangeCodeRepository.findOne({ where: { codeHash: hashCode(rawCode) } });
+    expect(record!.consumedAt).not.toBeNull();
+  });
+
+  it('consumeCode: rejects an already consumed code (single use)', async () => {
+    const user = await createUser(userRepository, { email: 'reuse@test.com', name: 'Reuse User' });
+    const { rawCode } = await exchangeCodeService.issueCode(user.id);
+
+    await exchangeCodeService.consumeCode(rawCode);
+
+    await expect(exchangeCodeService.consumeCode(rawCode)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('consumeCode: concurrent redemptions — exactly one wins', async () => {
+    const user = await createUser(userRepository, { email: 'race@test.com', name: 'Race User' });
+    const { rawCode } = await exchangeCodeService.issueCode(user.id);
+
+    const attempts = await Promise.allSettled([
+      exchangeCodeService.consumeCode(rawCode),
+      exchangeCodeService.consumeCode(rawCode),
+      exchangeCodeService.consumeCode(rawCode),
+    ]);
+
+    const fulfilled = attempts.filter((a) => a.status === 'fulfilled');
+    const rejected = attempts.filter((a) => a.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(2);
+    expect(fulfilled[0].value).toBe(user.id);
+  });
+
+  it('consumeCode: rejects an expired code', async () => {
+    const user = await createUser(userRepository, { email: 'expired@test.com', name: 'Expired User' });
+    const { rawCode } = await exchangeCodeService.issueCode(user.id);
+
+    await exchangeCodeRepository.update(
+      { codeHash: hashCode(rawCode) },
+      { expiresAt: new Date('2000-01-01') },
+    );
+
+    await expect(exchangeCodeService.consumeCode(rawCode)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('consumeCode: rejects an unknown code', async () => {
+    await expect(exchangeCodeService.consumeCode('nonexistent-code')).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('deleteExpiredCodes: removes expired codes and keeps active ones', async () => {
+    const user = await createUser(userRepository, { email: 'cleanup@test.com', name: 'Cleanup User' });
+    const { rawCode: activeRawCode } = await exchangeCodeService.issueCode(user.id);
+    const { rawCode: expiredRawCode } = await exchangeCodeService.issueCode(user.id);
+
+    await exchangeCodeRepository.update(
+      { codeHash: hashCode(expiredRawCode) },
+      { expiresAt: new Date('2000-01-01') },
+    );
+
+    await exchangeCodeService.deleteExpiredCodes();
+
+    const remaining = await exchangeCodeRepository.find({ where: { userId: user.id } });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].codeHash).toBe(hashCode(activeRawCode));
+  });
+});

--- a/apps/backend/test/auth.e2e-spec.ts
+++ b/apps/backend/test/auth.e2e-spec.ts
@@ -100,4 +100,14 @@ describe('AuthController (e2e)', () => {
     expect(typeof responseBody.data.createdAt).toBe('string');
     expect(typeof responseBody.data.updatedAt).toBe('string');
   });
+
+  it('POST /api/auth/exchange should return 401 for an unknown code', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+    await request(httpServer).post('/api/auth/exchange').send({ code: 'nonexistent-code' }).expect(401);
+  });
+
+  it('POST /api/auth/exchange should return 400 when code is missing', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+    await request(httpServer).post('/api/auth/exchange').send({}).expect(400);
+  });
 });

--- a/apps/frontend/src/api/client.test.ts
+++ b/apps/frontend/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { apiRequest, REFRESH_TOKEN_KEY } from '@/api/client';
+import { apiRequest, setAccessToken, REFRESH_TOKEN_KEY } from '@/api/client';
 
 vi.mock('@/config/env', () => ({
   ENV: { API_URL: 'http://test.api' },
@@ -24,6 +24,7 @@ describe('apiRequest', () => {
   });
 
   afterEach(() => {
+    setAccessToken(null);
     vi.unstubAllGlobals();
   });
 
@@ -73,7 +74,7 @@ describe('apiRequest', () => {
 
   describe('401 / token refresh', () => {
     it('retries request with new token after successful refresh', async () => {
-      localStorage.setItem('token', 'old-token');
+      setAccessToken('old-token');
       localStorage.setItem(REFRESH_TOKEN_KEY, 'refresh-token');
 
       vi.mocked(fetch)
@@ -84,12 +85,15 @@ describe('apiRequest', () => {
       const result = await apiRequest<{ id: string }>('/events/1');
 
       expect(result).toEqual({ id: '1' });
-      expect(localStorage.getItem('token')).toBe('new-token');
+      // The retried request must carry the freshly issued access token
+      const retryHeaders = new Headers((vi.mocked(fetch).mock.calls[2][1] as RequestInit).headers);
+      expect(retryHeaders.get('Authorization')).toBe('Bearer new-token');
+      expect(localStorage.getItem('token')).toBeNull();
       expect(fetch).toHaveBeenCalledTimes(3);
     });
 
     it('removes refresh_token and dispatches auth:logout when refresh endpoint returns non-ok', async () => {
-      localStorage.setItem('token', 'old-token');
+      setAccessToken('old-token');
       localStorage.setItem(REFRESH_TOKEN_KEY, 'refresh-token');
 
       vi.mocked(fetch)
@@ -108,7 +112,7 @@ describe('apiRequest', () => {
     });
 
     it('dispatches auth:logout immediately when no refresh token is stored', async () => {
-      localStorage.setItem('token', 'old-token');
+      setAccessToken('old-token');
 
       vi.mocked(fetch).mockResolvedValueOnce(mockResponse(401, { message: 'Unauthorized' }));
 
@@ -124,7 +128,7 @@ describe('apiRequest', () => {
     });
 
     it('does not retry /auth/refresh endpoint on 401', async () => {
-      localStorage.setItem('token', 'old-token');
+      setAccessToken('old-token');
       localStorage.setItem(REFRESH_TOKEN_KEY, 'refresh-token');
 
       vi.mocked(fetch).mockResolvedValueOnce(mockResponse(401, { message: 'Invalid' }));
@@ -134,7 +138,7 @@ describe('apiRequest', () => {
     });
 
     it('deduplicates concurrent refresh calls (race condition)', async () => {
-      localStorage.setItem('token', 'old-token');
+      setAccessToken('old-token');
       localStorage.setItem(REFRESH_TOKEN_KEY, 'refresh-token');
 
       vi.mocked(fetch)

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -9,15 +9,19 @@ interface ApiRequestInit extends RequestInit {
   _retried?: boolean;
 }
 
-function getAuthToken() {
-  return localStorage.getItem('token');
+// The access token lives only in memory so a persistent XSS cannot read it
+// from storage; on page load a new one is obtained via the refresh token.
+let accessToken: string | null = null;
+
+export function setAccessToken(token: string | null) {
+  accessToken = token;
 }
 
 function getRefreshToken() {
   return localStorage.getItem(REFRESH_TOKEN_KEY);
 }
 
-async function refreshAccessToken(): Promise<string | null> {
+export async function refreshAccessToken(): Promise<string | null> {
   if (refreshPromise) {
     return refreshPromise;
   }
@@ -41,7 +45,11 @@ async function refreshAccessToken(): Promise<string | null> {
       if (newRefreshToken) {
         localStorage.setItem(REFRESH_TOKEN_KEY, newRefreshToken);
       }
-      return body.data?.accessToken ?? null;
+      const newAccessToken = body.data?.accessToken ?? null;
+      if (newAccessToken) {
+        setAccessToken(newAccessToken);
+      }
+      return newAccessToken;
     })
     .catch(() => null)
     .finally(() => {
@@ -78,7 +86,7 @@ export async function apiRequest<T>(endpoint: string, options?: ApiRequestInit):
   const { _retried: hasRetried = false, ...baseOptions } = requestOptions;
 
   let response: Response;
-  const token = getAuthToken();
+  const token = accessToken;
   const isFormData = typeof FormData !== 'undefined' && baseOptions.body instanceof FormData;
 
   try {
@@ -107,7 +115,6 @@ export async function apiRequest<T>(endpoint: string, options?: ApiRequestInit):
       const newToken = await refreshAccessToken();
 
       if (newToken) {
-        localStorage.setItem('token', newToken);
         return apiRequest<T>(endpoint, {
           ...baseOptions,
           _retried: true,

--- a/apps/frontend/src/features/auth/AuthContext.test.tsx
+++ b/apps/frontend/src/features/auth/AuthContext.test.tsx
@@ -8,8 +8,15 @@ const resetTransactionModal = vi.fn();
 const resetToast = vi.fn();
 const resetDeleting = vi.fn();
 
+const { refreshAccessTokenMock, setAccessTokenMock } = vi.hoisted(() => ({
+  refreshAccessTokenMock: vi.fn(),
+  setAccessTokenMock: vi.fn(),
+}));
+
 vi.mock('@/api/client', () => ({
   REFRESH_TOKEN_KEY: 'refresh_token',
+  refreshAccessToken: refreshAccessTokenMock,
+  setAccessToken: setAccessTokenMock,
 }));
 
 vi.mock('@/shared/store/useEventFormModalStore', () => ({
@@ -61,18 +68,20 @@ describe('AuthProvider', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
     vi.clearAllMocks();
+    refreshAccessTokenMock.mockResolvedValue('my-jwt');
   });
 
-  it('sets loading to false when no token is stored', async () => {
+  it('sets loading to false without refreshing when no refresh token is stored', async () => {
     renderProvider();
     await waitFor(() => {
       expect(screen.getByTestId('loading')).toHaveTextContent('false');
     });
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('fetches user on mount when token is stored', async () => {
-    localStorage.setItem('token', 'my-jwt');
+  it('bootstraps the session from the refresh token on mount', async () => {
+    localStorage.setItem('refresh_token', 'stored-refresh');
     vi.mocked(fetch).mockResolvedValueOnce(userResponse());
 
     renderProvider();
@@ -80,11 +89,25 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('user')).toHaveTextContent('user@test.com');
     });
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('loading')).toHaveTextContent('false');
   });
 
+  it('sets loading to false without fetching user when the refresh fails', async () => {
+    localStorage.setItem('refresh_token', 'stored-refresh');
+    refreshAccessTokenMock.mockResolvedValue(null);
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toHaveTextContent('false');
+    });
+    expect(screen.getByTestId('user')).toHaveTextContent('null');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('clears user and token when /auth/me returns 401', async () => {
-    localStorage.setItem('token', 'expired-jwt');
+    localStorage.setItem('refresh_token', 'stored-refresh');
     vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 401 } as Response);
 
     renderProvider();
@@ -93,11 +116,11 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('loading')).toHaveTextContent('false');
     });
     expect(screen.getByTestId('user')).toHaveTextContent('null');
-    expect(localStorage.getItem('token')).toBeNull();
+    expect(setAccessTokenMock).toHaveBeenCalledWith(null);
   });
 
   it('sets error when /auth/me returns non-401 server error', async () => {
-    localStorage.setItem('token', 'my-jwt');
+    localStorage.setItem('refresh_token', 'stored-refresh');
     vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500 } as Response);
 
     renderProvider();
@@ -108,7 +131,7 @@ describe('AuthProvider', () => {
   });
 
   it('sets error on network failure during fetchUser', async () => {
-    localStorage.setItem('token', 'my-jwt');
+    localStorage.setItem('refresh_token', 'stored-refresh');
     vi.mocked(fetch).mockRejectedValueOnce(new Error('Network down'));
 
     renderProvider();
@@ -118,8 +141,8 @@ describe('AuthProvider', () => {
     });
   });
 
-  it('clears user, token and localStorage on logout', async () => {
-    localStorage.setItem('token', 'my-jwt');
+  it('clears user, in-memory token and stored refresh token on logout', async () => {
+    localStorage.setItem('refresh_token', 'stored-refresh');
     vi.mocked(fetch).mockResolvedValueOnce(userResponse());
 
     renderProvider();
@@ -133,11 +156,12 @@ describe('AuthProvider', () => {
     });
 
     expect(screen.getByTestId('user')).toHaveTextContent('null');
-    expect(localStorage.getItem('token')).toBeNull();
+    expect(setAccessTokenMock).toHaveBeenCalledWith(null);
+    expect(localStorage.getItem('refresh_token')).toBeNull();
   });
 
   it('resets all stores on logout', async () => {
-    localStorage.setItem('token', 'my-jwt');
+    localStorage.setItem('refresh_token', 'stored-refresh');
     vi.mocked(fetch).mockResolvedValueOnce(userResponse());
 
     renderProvider();
@@ -157,7 +181,7 @@ describe('AuthProvider', () => {
   });
 
   it('calls logout when auth:logout event is dispatched', async () => {
-    localStorage.setItem('token', 'my-jwt');
+    localStorage.setItem('refresh_token', 'stored-refresh');
     vi.mocked(fetch).mockResolvedValueOnce(userResponse());
 
     renderProvider();
@@ -173,6 +197,6 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('user')).toHaveTextContent('null');
     });
-    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
   });
 });

--- a/apps/frontend/src/features/auth/AuthContext.tsx
+++ b/apps/frontend/src/features/auth/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useEffect, useState, type ReactNode } from 'react';
-import { REFRESH_TOKEN_KEY } from '@/api/client';
+import { REFRESH_TOKEN_KEY, refreshAccessToken, setAccessToken } from '@/api/client';
 import type { AuthContextType, AuthProvider, User } from './types';
 import { useEventFormModalStore } from '@/shared/store/useEventFormModalStore';
 import { useTransactionModalStore } from '@/shared/store/useTransactionModalStore';
@@ -7,8 +7,6 @@ import { useDeletingStore } from '@/shared/store/useDeletingStore';
 import { useToastStore } from '@/shared/store/useToastStore';
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
-
-const TOKEN_KEY = 'token';
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -32,7 +30,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (res.status === 401) {
         setUser(null);
         setToken(null);
-        localStorage.removeItem(TOKEN_KEY);
+        setAccessToken(null);
         return null;
       }
 
@@ -49,14 +47,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
-    if (!storedToken) {
+    // The access token lives only in memory: on page load, bootstrap the
+    // session from the stored refresh token instead.
+    const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+    if (!refreshToken) {
       setLoading(false);
       return;
     }
 
-    setToken(storedToken);
-    void fetchUser(storedToken);
+    void (async () => {
+      const newAccessToken = await refreshAccessToken();
+      if (!newAccessToken) {
+        setLoading(false);
+        return;
+      }
+
+      setToken(newAccessToken);
+      await fetchUser(newAccessToken);
+    })();
   }, [fetchUser]);
 
   const login = (provider: AuthProvider = 'google') => {
@@ -77,7 +85,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     setUser(null);
     setToken(null);
-    localStorage.removeItem(TOKEN_KEY);
+    setAccessToken(null);
     localStorage.removeItem(REFRESH_TOKEN_KEY);
 
     useEventFormModalStore.getState().reset();
@@ -111,7 +119,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const setAuth = (nextUser: User, nextToken: string) => {
     setUser(nextUser);
     setToken(nextToken);
-    localStorage.setItem(TOKEN_KEY, nextToken);
+    setAccessToken(nextToken);
   };
 
   const refreshUser = useCallback(() => {

--- a/apps/frontend/src/pages/AuthCallback.test.tsx
+++ b/apps/frontend/src/pages/AuthCallback.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthCallback } from './AuthCallback';
+
+const navigateMock = vi.fn();
+const setAuthMock = vi.fn();
+
+vi.mock('@/config/env', () => ({
+  ENV: { API_URL: 'http://test.api' },
+}));
+
+vi.mock('@/api/client', () => ({
+  REFRESH_TOKEN_KEY: 'refresh_token',
+}));
+
+vi.mock('@/features/auth/useAuth', () => ({
+  useAuth: () => ({ setAuth: setAuthMock }),
+}));
+
+vi.mock('@/shared/hooks/useI18nNamespacesReady', () => ({
+  useI18nNamespacesReady: () => true,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function renderCallback(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/auth/callback${search}`]}>
+      <AuthCallback />
+    </MemoryRouter>,
+  );
+}
+
+describe('AuthCallback', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.clearAllMocks();
+  });
+
+  it('redeems the exchange code, stores the refresh token and authenticates the user', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(jsonResponse(200, { data: { accessToken: 'access-jwt', refreshToken: 'refresh-raw' } }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { data: { id: 'user-1', email: 'user@test.com', name: 'User', role: 'user' } }),
+      );
+
+    renderCallback('?success=true&code=one-time-code');
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/', { replace: true });
+    });
+
+    const exchangeCall = vi.mocked(fetch).mock.calls[0];
+    expect(String(exchangeCall[0])).toBe('http://test.api/auth/exchange');
+    expect(JSON.parse((exchangeCall[1] as RequestInit).body as string)).toEqual({ code: 'one-time-code' });
+
+    expect(localStorage.getItem('refresh_token')).toBe('refresh-raw');
+    expect(setAuthMock).toHaveBeenCalledWith(
+      { id: 'user-1', email: 'user@test.com', name: 'User', avatar: undefined, role: 'user' },
+      'access-jwt',
+    );
+  });
+
+  it('navigates home unauthenticated when the exchange fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(401, { message: 'Invalid or expired exchange code' }));
+
+    renderCallback('?success=true&code=stale-code');
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/', { replace: true });
+    });
+
+    expect(setAuthMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
+  it('navigates home without calling the API when no code is present', async () => {
+    renderCallback('?success=true');
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/', { replace: true });
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(setAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the loading state while the exchange is in flight', () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+
+    renderCallback('?success=true&code=one-time-code');
+
+    expect(screen.getByText('loading')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/AuthCallback.tsx
+++ b/apps/frontend/src/pages/AuthCallback.tsx
@@ -22,29 +22,27 @@ export function AuthCallback() {
     bootstrappedRef.current = true;
 
     const params = new URLSearchParams(location.search);
-    const refreshToken = params.get('refreshToken');
-    if (!params.get('success') || !refreshToken) {
+    const code = params.get('code');
+    if (!params.get('success') || !code) {
       navigate('/', { replace: true });
       return;
     }
 
-    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
-
     async function bootstrap() {
       try {
-        const refreshRes = await fetch(`${ENV.API_URL}/auth/refresh`, {
+        // Redeem the one-time exchange code for the token pair; the refresh
+        // token itself never travels in the callback URL.
+        const exchangeRes = await fetch(`${ENV.API_URL}/auth/exchange`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ refreshToken }),
+          body: JSON.stringify({ code }),
         });
-        if (!refreshRes.ok) throw new Error('refresh failed');
-        const refreshBody = (await refreshRes.json()) as { data?: { accessToken?: string; refreshToken?: string } };
-        const accessToken = refreshBody.data?.accessToken;
-        const newRefreshToken = refreshBody.data?.refreshToken;
-        if (!accessToken) throw new Error('no access token');
-        if (newRefreshToken) {
-          localStorage.setItem(REFRESH_TOKEN_KEY, newRefreshToken);
-        }
+        if (!exchangeRes.ok) throw new Error('exchange failed');
+        const exchangeBody = (await exchangeRes.json()) as { data?: { accessToken?: string; refreshToken?: string } };
+        const accessToken = exchangeBody.data?.accessToken;
+        const refreshToken = exchangeBody.data?.refreshToken;
+        if (!accessToken || !refreshToken) throw new Error('no tokens');
+        localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
 
         const meRes = await fetch(`${ENV.API_URL}/auth/me`, {
           headers: { Authorization: `Bearer ${accessToken}` },


### PR DESCRIPTION
Closes #92

## Qué problema resuelve

El callback OAuth (Google/Microsoft) redirigía al frontend con el refresh token en texto plano como
query param (`?refreshToken=...`). Eso lo expone en el historial del navegador, en logs de proxies/CDN
y en el `Referer` de cualquier request que se dispare desde esa página.

## Cambios

**Backend**
- Nueva tabla `auth_exchange_codes` (+ migración) y `AuthExchangeCodeService`: emite códigos de un solo
  uso (hash SHA-256, TTL configurable vía `AUTH_EXCHANGE_CODE_TTL_SECONDS`, por defecto 60s) y los
  consume de forma atómica (`UPDATE ... RETURNING` condicional, a prueba de doble canje concurrente).
- Los callbacks OAuth ahora redirigen con `?code=...` en vez de `?refreshToken=...`.
- Nuevo endpoint `POST /auth/exchange`: canjea el código por el par de tokens.
- Throttling por método: `exchange` 5/min, `refresh` 30/min.
- El refresh token ya no se crea hasta que el código se canjea.

**Frontend**
- El access token vive solo en memoria (`setAccessToken` en `api/client`), ya no en `localStorage`.
- `AuthContext` arranca la sesión a partir del refresh token guardado al cargar la página.
- `AuthCallback` canjea el código de intercambio vía `POST /auth/exchange`.

**Tests**
- Specs nuevos de unit/integración para `AuthExchangeCodeService` (incluye canje concurrente).
- Specs del controller actualizados.
- Tests nuevos de `AuthCallback`.
- Tests de `client`/`AuthContext` migrados al modelo de token en memoria.

## Alcance

**Fuera de este PR:** el criterio de aceptación "el refresh token nunca es legible desde JavaScript"
(cookie httpOnly) queda pendiente. Frontend (GitHub Pages) y backend (Render) son cross-site —
`github.io` y `onrender.com` están ambos en la Public Suffix List, así que no hay dominio registrable
común—; una cookie `SameSite=None` la bloquea Safari/ITP y la particiona Firefox. Requiere una decisión
de infraestructura previa (dominio propio o mismo origen), así que se traslada a una issue de
seguimiento independiente.

## Verificación

- `pnpm lint && pnpm test && pnpm build` en verde en local: 152 unit + 31 integración + 37 e2e de
  backend, 229 tests de frontend, build completo del monorepo.
- **Pendiente de verificación manual** (no automatizable en este PR):
  - Login completo Google/Microsoft en local, de principio a fin.
  - Reutilizar la URL del callback (con el código ya canjeado) — debe fallar.
  - Recargar la página mantiene la sesión (bootstrap desde el refresh token).
  - Logout limpia el estado por completo (memoria + almacenamiento).
