### PR TITLE
docs(ci): corregir los estados del tablero en gh-project.md

### DIFF
--- a/.claude/gh-project.md
+++ b/.claude/gh-project.md
@@ -37,12 +37,14 @@ y start descritos en [`DEPLOYMENT.md`](../DEPLOYMENT.md)).
 | Estado | option-id |
 |---|---|
 | Todo | `f75ad846` |
+| Ready | `90c1ddbf` |
 | In Progress | `47fc9ee4` |
+| In Review | `97172d5f` |
 | Done | `98236657` |
 
-> El tablero tiene **tres** estados, no los cinco del flujo genérico. Mapeo:
-> `Ready` → **Todo**, `In progress` → **In Progress**, `In review` → se queda en **In Progress**
-> (no hay estado de revisión), `Done` → **Done**.
+> El tablero tiene los cinco estados del flujo genérico, así que no hace falta ningún mapeo: cada
+> estado de la skill se corresponde con el del mismo nombre. Verifica los ids con
+> `gh project field-list 1 --owner MrClit --format json` si algo no cuadra.
 
 ## Labels
 


### PR DESCRIPTION
## Contexto

`.claude/gh-project.md` declaraba que el campo Status del tablero **Fri€nds** tenía tres estados
(`Todo`, `In Progress`, `Done`), con una nota que decía "In review → se queda en In Progress
(no hay estado de revisión)". El tablero real, verificado con
`gh project field-list 1 --owner MrClit --format json`, tiene **cinco** estados:

```
Todo         f75ad846
Ready        90c1ddbf
In Progress  47fc9ee4
In Review    97172d5f
Done         98236657
```

El `field-id` del doc era correcto; faltaban las opciones `Ready` e `In Review`.

Consecuencia directa: al trabajar la issue #93 siguiendo el mapeo erróneo del doc, el PR #115 se
abrió y la issue se movió (y quedó) en **In Progress** en vez de en **In Review**, que es donde le
correspondía una vez el PR estaba abierto con los checks en verde.

## Cambios

- Añadidas las filas `Ready` (`90c1ddbf`) e `In Review` (`97172d5f`) a la tabla de option-ids.
- Sustituida la nota del mapeo de tres estados por la correspondencia directa (cada estado de la
  skill genérica tiene su equivalente exacto en el tablero) y el comando de reverificación
  (`gh project field-list 1 --owner MrClit --format json`) para el futuro.

## Verificación

- Cambio limitado a documentación, sin código ni tests afectados.
- Ids reverificados contra el tablero real antes de commitear.