### PR TITLE
feat(backend): añadir cabeceras de seguridad helmet

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -55,6 +55,7 @@
     "cookie-parser": "^1.4.7",
     "decimal.js": "^10.6.0",
     "dotenv": "^17.4.2",
+    "helmet": "^8.3.0",
     "joi": "^18.2.3",
     "nestjs-pino": "^4.6.1",
     "passport": "^0.7.0",

--- a/apps/backend/src/common/bootstrap/configure-app.ts
+++ b/apps/backend/src/common/bootstrap/configure-app.ts
@@ -1,0 +1,37 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
+import helmet from 'helmet';
+import { HttpExceptionFilter } from '../filters/http-exception.filter';
+import { TransformInterceptor } from '../interceptors/transform.interceptor';
+
+/**
+ * Applies the application configuration shared by the production bootstrap and the test harness:
+ * security headers, global prefix, validation, error contract and response envelope.
+ *
+ * Environment-dependent wiring (CORS, Swagger, listen) stays in `main.ts`, since it relies on
+ * runtime configuration that does not apply to the in-memory app used by tests.
+ */
+export function configureApp(app: INestApplication): void {
+  // Security headers first, so they also cover responses produced by later middleware.
+  // Helmet's defaults are compatible with the bundled Swagger UI: it loads every script as a
+  // same-origin external file, and its inline <style> blocks fall under the default style-src.
+  app.use(helmet());
+
+  app.setGlobalPrefix('api');
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true, // Strip properties that don't have decorators
+      forbidNonWhitelisted: true, // Throw error if non-whitelisted properties are present
+      transform: true, // Automatically transform payloads to DTO instances
+      transformOptions: {
+        enableImplicitConversion: true, // Enable implicit type conversion
+      },
+    }),
+  );
+
+  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalInterceptors(new TransformInterceptor());
+
+  app.use(cookieParser());
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,12 +1,10 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, Logger } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { AppModule } from './app.module';
-import { HttpExceptionFilter } from './common/filters/http-exception.filter';
-import { TransformInterceptor } from './common/interceptors/transform.interceptor';
-import cookieParser from 'cookie-parser';
+import { configureApp } from './common/bootstrap/configure-app';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -25,28 +23,8 @@ async function bootstrap() {
     allowedHeaders: ['Content-Type', 'Authorization'],
   });
 
-  // Global API prefix
-  app.setGlobalPrefix('api');
-
-  // Global Validation Pipe
-  app.useGlobalPipes(
-    new ValidationPipe({
-      whitelist: true, // Strip properties that don't have decorators
-      forbidNonWhitelisted: true, // Throw error if non-whitelisted properties are present
-      transform: true, // Automatically transform payloads to DTO instances
-      transformOptions: {
-        enableImplicitConversion: true, // Enable implicit type conversion
-      },
-    }),
-  );
-
-  // Global Exception Filter
-  app.useGlobalFilters(new HttpExceptionFilter());
-
-  // Global Response Transformer
-  app.useGlobalInterceptors(new TransformInterceptor());
-
-  app.use(cookieParser());
+  // Security headers, global prefix, validation, error contract and response envelope
+  configureApp(app);
 
   // Swagger Configuration
   const config = new DocumentBuilder()

--- a/apps/backend/test/security-headers.e2e-spec.ts
+++ b/apps/backend/test/security-headers.e2e-spec.ts
@@ -1,0 +1,48 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { applyAppTestConfig } from './utils/test-app-config';
+
+describe('Security headers (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    applyAppTestConfig(app);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // Assertions check for presence and meaningful substrings rather than exact header values:
+  // helmet changes its defaults across major versions, and a literal match would break on every
+  // bump without signalling a real regression.
+  it('sends helmet security headers on API responses', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(httpServer).get('/api/health/live').expect(200);
+
+    expect(response.headers['content-security-policy']).toContain("default-src 'self'");
+    expect(response.headers['content-security-policy']).toContain("script-src 'self'");
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['x-frame-options']).toBe('SAMEORIGIN');
+    expect(response.headers['strict-transport-security']).toContain('max-age=');
+    expect(response.headers['cross-origin-resource-policy']).toBe('same-origin');
+    expect(response.headers['referrer-policy']).toBe('no-referrer');
+  });
+
+  it('does not disclose the underlying framework', async () => {
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+
+    const response = await request(httpServer).get('/api/health/live').expect(200);
+
+    expect(response.headers['x-powered-by']).toBeUndefined();
+  });
+});

--- a/apps/backend/test/utils/test-app-config.ts
+++ b/apps/backend/test/utils/test-app-config.ts
@@ -1,21 +1,10 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { HttpExceptionFilter } from '../../src/common/filters/http-exception.filter';
-import { TransformInterceptor } from '../../src/common/interceptors/transform.interceptor';
+import { INestApplication } from '@nestjs/common';
+import { configureApp } from '../../src/common/bootstrap/configure-app';
 
+/**
+ * Applies the same configuration the production bootstrap uses, so tests exercise the real
+ * middleware stack (security headers included) instead of a divergent copy of it.
+ */
 export function applyAppTestConfig(app: INestApplication): void {
-  app.setGlobalPrefix('api');
-
-  app.useGlobalPipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-      transformOptions: {
-        enableImplicitConversion: true,
-      },
-    }),
-  );
-
-  app.useGlobalFilters(new HttpExceptionFilter());
-  app.useGlobalInterceptors(new TransformInterceptor());
+  configureApp(app);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      helmet:
+        specifier: ^8.3.0
+        version: 8.3.0
       joi:
         specifier: ^18.2.3
         version: 18.2.3
@@ -3941,6 +3944,10 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  helmet@8.3.0:
+    resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
+    engines: {node: '>=18.0.0'}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -8208,10 +8215,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)
@@ -8224,10 +8231,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
@@ -9737,6 +9744,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@8.3.0: {}
 
   help-me@5.0.0: {}
 
@@ -11557,7 +11566,7 @@ snapshots:
 
   typescript-eslint@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3)
@@ -11568,7 +11577,7 @@ snapshots:
 
   typescript-eslint@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)


### PR DESCRIPTION
Closes #94

## Qué problema resuelve

El backend no enviaba cabeceras de seguridad HTTP estándar (CSP, HSTS, `X-Content-Type-Options`,
`X-Frame-Options`, etc.), y exponía `X-Powered-By`.

## Cambios

- Activa **helmet** como middleware global.
- De paso extrae a `configureApp()` (nuevo `apps/backend/src/common/bootstrap/configure-app.ts`) la
  configuración que `main.ts` y el harness de tests duplicaban (helmet + prefijo `api` + ValidationPipe
  + HttpExceptionFilter + TransformInterceptor + cookieParser), para que el e2e ejerza exactamente la
  config de producción en vez de una copia divergente. CORS, Swagger y `listen` se quedan en `main.ts`
  porque dependen de env vars.
- Nuevo e2e `apps/backend/test/security-headers.e2e-spec.ts` sobre `GET /api/health/live`.

### Por qué los defaults de helmet, sin tocar el CSP

- El HTML de `@nestjs/swagger` 11.4.6 carga todos sus scripts como ficheros externos del mismo
  origen (cero `<script>` inline) y sus `<style>` inline caen bajo el `style-src` por defecto.
- `Cross-Origin-Resource-Policy: same-origin` no afecta al frontend porque el check de CORP solo
  aplica a peticiones en modo `no-cors`, no a los `fetch` con CORS.
- `Cross-Origin-Opener-Policy: same-origin` no rompe el OAuth porque es redirección completa, no popup.

## Verificación

- `pnpm lint`, `pnpm build` y `pnpm test` en verde. Backend: 23 suites/154 tests unit, 6/31
  integración, 5/39 e2e. Frontend: 33 ficheros/229 tests.
- Cabeceras confirmadas en respuesta real: CSP, HSTS, `X-Content-Type-Options: nosniff`,
  `X-Frame-Options: SAMEORIGIN`, CORP, COOP, `Referrer-Policy: no-referrer`. `X-Powered-By` deja de
  emitirse.
- `/api/docs` cargado en Chrome headless: Swagger UI arranca (`window.ui`), 32 bloques de operación
  renderizados, **cero** errores de consola o requests fallidas. "Try it out" sobre
  `/api/health/live` devuelve `{"data":{"status":"ok",…}}`, confirmando que `connect-src` no bloquea
  la propia UI. Los 5 assets de Swagger responden 200 con su MIME correcto, relevante con `nosniff`
  activo.

### Nota de test

Las aserciones del e2e comprueban presencia y substrings, no la cadena exacta del CSP, porque helmet
cambia sus defaults entre majors y un match literal se rompería en cada bump sin señalar una
regresión real.

## Hallazgo colateral

Al implementar esta issue se detectó que `cookie-parser` está registrado como middleware global pero
ningún endpoint lee cookies. Queda anotado en la issue #117 para decidirlo aparte, fuera del alcance
de este PR.