### PR TITLE
fix(backend): validate the /users/search query and document the user directory exposure

### DIFF
--- a/apps/backend/http-requests/users.http.example
+++ b/apps/backend/http-requests/users.http.example
@@ -9,6 +9,8 @@
 ###############################################
 # Retrieve all users (for participant selection)
 # @returns List of all users with basic info (id, email, name, avatar, role)
+# NOTE: this deliberately exposes the whole directory, email included, to any authenticated user.
+# See the endpoint description in /api/docs for the decision and when to revisit it.
 GET {{baseUrl}}/users
 Authorization: Bearer {{token}}
 
@@ -16,8 +18,8 @@ Authorization: Bearer {{token}}
 # SEARCH USERS
 ###############################################
 # Search users by name or email
-# @param q - Search query string
-# @returns Filtered list of users matching the query
+# @param q - Search query string, required, 2 to 100 characters (trimmed)
+# @returns Filtered list of users matching the query, max 20
 
 ### Search by name
 GET {{baseUrl}}/users/search?q=john
@@ -31,6 +33,14 @@ Authorization: Bearer {{token}}
 GET {{baseUrl}}/users/search?q=gma
 Authorization: Bearer {{token}}
 
-### Search with empty query (should return all users or empty)
+### Search with empty query (400 - q is required)
 GET {{baseUrl}}/users/search?q=
+Authorization: Bearer {{token}}
+
+### Search with a single character (400 - minimum length is 2)
+GET {{baseUrl}}/users/search?q=j
+Authorization: Bearer {{token}}
+
+### Search with a LIKE wildcard (200 - % is matched literally, not as a pattern)
+GET {{baseUrl}}/users/search?q=%25%25
 Authorization: Bearer {{token}}

--- a/apps/backend/src/modules/users/dto/search-users-query.dto.ts
+++ b/apps/backend/src/modules/users/dto/search-users-query.dto.ts
@@ -1,0 +1,26 @@
+import { Transform } from 'class-transformer';
+import { IsString, MaxLength, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+const SEARCH_QUERY_MIN_LENGTH = 2;
+const SEARCH_QUERY_MAX_LENGTH = 100;
+
+/**
+ * DTO for the user search query parameters (INPUT)
+ * Validates the `q` param before it reaches the ILIKE clause built by UsersService.search
+ */
+export class SearchUsersQueryDto {
+  @ApiProperty({
+    description: 'Search term matched against the user name and email. Wildcards are matched literally.',
+    minLength: SEARCH_QUERY_MIN_LENGTH,
+    maxLength: SEARCH_QUERY_MAX_LENGTH,
+    example: 'ana',
+  })
+  // Trim before the length validators run, so a whitespace-only query is rejected
+  // instead of searching for spaces.
+  @Transform(({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MinLength(SEARCH_QUERY_MIN_LENGTH)
+  @MaxLength(SEARCH_QUERY_MAX_LENGTH)
+  q: string;
+}

--- a/apps/backend/src/modules/users/users.controller.spec.ts
+++ b/apps/backend/src/modules/users/users.controller.spec.ts
@@ -59,7 +59,7 @@ describe('UsersController', () => {
     const users = [{ id: 'u1', email: 'alice@example.com', name: 'Alice' }];
     usersService.search.mockResolvedValue(users);
 
-    const result = await controller.search('ali');
+    const result = await controller.search({ q: 'ali' });
 
     expect(result).toEqual(users);
     expect(usersService.search).toHaveBeenCalledWith('ali');

--- a/apps/backend/src/modules/users/users.controller.ts
+++ b/apps/backend/src/modules/users/users.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApiErrorResponseDto } from '../../common/dto/api-error-response.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { AuthGuard } from '@nestjs/passport';
@@ -19,6 +19,7 @@ import type { AuthenticatedUser } from '../../common/types/authenticated-user.ty
 import { AvatarService } from '../auth/services/avatar.service';
 import { RolesGuard } from '../auth/roles/roles.guard';
 import { CurrentUserProfileDto } from './dto/current-user-profile.dto';
+import { SearchUsersQueryDto } from './dto/search-users-query.dto';
 import { UpdateCurrentUserProfileDto } from './dto/update-current-user-profile.dto';
 import { UsersService } from './users.service';
 import { UserDto } from './dto/user.dto';
@@ -43,18 +44,30 @@ export class UsersController {
   ) {}
 
   @Get()
-  @ApiOperation({ summary: 'Get all users for participant selection' })
+  @ApiOperation({
+    summary: 'Get all users for participant selection',
+    description:
+      'Returns the whole user directory, email included, to any authenticated user. This is a ' +
+      'deliberate product decision: the participant picker needs the full list, and email is what ' +
+      'disambiguates people with the same name. It is acceptable only while sign-up stays limited ' +
+      'to the circle of friends this app was built for. Revisit it once registration opens up or ' +
+      'the directory grows past a few hundred users — `GET /users/search` is the bounded ' +
+      'alternative to migrate to.',
+  })
   @ApiStandardResponse(200, 'Users retrieved successfully', UserDto, true)
   findAll() {
     return this.usersService.findAll();
   }
 
   @Get('search')
-  @ApiOperation({ summary: 'Search users by name or email' })
-  @ApiQuery({ name: 'q', description: 'Search query' })
+  @ApiOperation({
+    summary: 'Search users by name or email',
+    description: 'Wildcards in the search term are matched literally, not interpreted as patterns.',
+  })
   @ApiStandardResponse(200, 'Users found', UserDto, true)
-  search(@Query('q') query: string) {
-    return this.usersService.search(query);
+  @ApiResponse({ status: 400, description: 'Invalid or missing search query', type: ApiErrorResponseDto })
+  search(@Query() { q }: SearchUsersQueryDto) {
+    return this.usersService.search(q);
   }
 
   @Get('me')

--- a/apps/backend/src/modules/users/users.service.spec.ts
+++ b/apps/backend/src/modules/users/users.service.spec.ts
@@ -129,6 +129,29 @@ describe('UsersService', () => {
     expect(queryBuilder.getMany).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ['50%', '%50\\%%'],
+    ['a_b', '%a\\_b%'],
+    ['c:\\', '%c:\\\\%'],
+    ['%_\\', '%\\%\\_\\\\%'],
+  ])('search escapes LIKE wildcards in %p', async (rawQuery, expectedPattern) => {
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    mockRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+    await service.search(rawQuery);
+
+    expect(queryBuilder.where).toHaveBeenCalledWith('(user.name ILIKE :query OR user.email ILIKE :query)', {
+      query: expectedPattern,
+    });
+  });
+
   it('getCurrentUserProfileByIdOrThrow returns current user profile projection', async () => {
     const now = new Date();
     const user = {

--- a/apps/backend/src/modules/users/users.service.ts
+++ b/apps/backend/src/modules/users/users.service.ts
@@ -87,6 +87,16 @@ export class UsersService {
     return this.toCurrentUserProfile(user);
   }
 
+  /**
+   * Returns the whole user directory — including every user's email — to any authenticated caller.
+   *
+   * This is a deliberate product decision, not an oversight: the participant picker needs to offer
+   * the full list of users, and email is what disambiguates people with the same name. It is
+   * acceptable only while sign-up stays limited to the circle of friends the app was built for.
+   *
+   * Revisit it once that stops holding — registration opening up, or the directory growing past a
+   * few hundred users. `search` is the bounded alternative the client should migrate to then.
+   */
   async findAll(): Promise<User[]> {
     return this.userRepository.find({
       select: ['id', 'email', 'name', 'avatar', 'role'],
@@ -95,10 +105,16 @@ export class UsersService {
   }
 
   async search(query: string): Promise<User[]> {
+    // Escape the LIKE wildcards so the caller's input is matched literally instead of being
+    // interpreted as a pattern. The backslash itself goes first, otherwise it would be escaped
+    // twice. PostgreSQL uses a backslash as the default LIKE escape character, so no ESCAPE
+    // clause is needed.
+    const escapedQuery = query.replace(/[\\%_]/g, (char) => `\\${char}`);
+
     return this.userRepository
       .createQueryBuilder('user')
       .where('(user.name ILIKE :query OR user.email ILIKE :query)', {
-        query: `%${query}%`,
+        query: `%${escapedQuery}%`,
       })
       .andWhere('user.deleted_at IS NULL')
       .select(['user.id', 'user.email', 'user.name', 'user.avatar', 'user.role'])

--- a/apps/backend/test/users-search.e2e-spec.ts
+++ b/apps/backend/test/users-search.e2e-spec.ts
@@ -1,0 +1,115 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { Repository } from 'typeorm';
+
+import { AppModule } from '../src/app.module';
+import { User } from '../src/modules/users/user.entity';
+import { applyAppTestConfig } from './utils/test-app-config';
+import { createUser } from './utils/test-factories';
+import { buildAuthHeader, getDataFromBody } from './utils/test-http-helpers';
+
+/**
+ * The `400` responses only exist at the HTTP level: they are produced by the global ValidationPipe,
+ * so they cannot be exercised by calling the controller directly.
+ */
+describe('Users Search API (e2e)', () => {
+  let app: INestApplication;
+  let jwtService: JwtService;
+  let userRepository: Repository<User>;
+  let authHeader: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    applyAppTestConfig(app);
+    await app.init();
+
+    jwtService = app.get(JwtService);
+    userRepository = app.get<Repository<User>>(getRepositoryToken(User));
+  });
+
+  beforeEach(async () => {
+    await userRepository.createQueryBuilder().delete().from(User).execute();
+
+    const searcher = await createUser(userRepository, {
+      email: 'searcher@test.com',
+      name: 'Searcher',
+    });
+    authHeader = buildAuthHeader(jwtService, searcher);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const getHttpServer = () => app.getHttpServer() as Parameters<typeof request>[0];
+
+  it.each([
+    ['a missing query', '/api/users/search'],
+    ['an empty query', '/api/users/search?q='],
+    ['a whitespace-only query', '/api/users/search?q=%20%20'],
+    ['a query below the minimum length', '/api/users/search?q=a'],
+    ['a query above the maximum length', `/api/users/search?q=${'a'.repeat(101)}`],
+  ])('returns 400 for %s', async (_description, url) => {
+    const response = await request(getHttpServer()).get(url).set('Authorization', authHeader).expect(400);
+
+    expect(response.body).toMatchObject({
+      statusCode: 400,
+      method: 'GET',
+    });
+  });
+
+  it('returns 400 for unknown query parameters', async () => {
+    await request(getHttpServer())
+      .get('/api/users/search?q=ana&limit=100')
+      .set('Authorization', authHeader)
+      .expect(400);
+  });
+
+  it('returns 401 without a token', async () => {
+    await request(getHttpServer()).get('/api/users/search?q=ana').expect(401);
+  });
+
+  it('returns the matching users for a valid query', async () => {
+    await createUser(userRepository, { email: 'ana@test.com', name: 'Ana' });
+    await createUser(userRepository, { email: 'bruno@test.com', name: 'Bruno' });
+
+    const response = await request(getHttpServer())
+      .get('/api/users/search?q=an')
+      .set('Authorization', authHeader)
+      .expect(200);
+
+    const data = getDataFromBody(response.body) as { name: string }[];
+    expect(data.map((user) => user.name)).toEqual(['Ana']);
+  });
+
+  it('trims the query before searching', async () => {
+    await createUser(userRepository, { email: 'ana@test.com', name: 'Ana' });
+
+    const response = await request(getHttpServer())
+      .get('/api/users/search?q=%20ana%20')
+      .set('Authorization', authHeader)
+      .expect(200);
+
+    const data = getDataFromBody(response.body) as { name: string }[];
+    expect(data.map((user) => user.name)).toEqual(['Ana']);
+  });
+
+  it('does not interpret wildcards in the query', async () => {
+    await createUser(userRepository, { email: 'ana@test.com', name: 'Ana' });
+    await createUser(userRepository, { email: 'bruno@test.com', name: 'Bruno' });
+
+    const response = await request(getHttpServer())
+      .get('/api/users/search?q=%25%25')
+      .set('Authorization', authHeader)
+      .expect(200);
+
+    expect(getDataFromBody(response.body)).toEqual([]);
+  });
+});

--- a/apps/backend/test/users-search.int-spec.ts
+++ b/apps/backend/test/users-search.int-spec.ts
@@ -56,6 +56,35 @@ describe('UsersService.search (integration)', () => {
     expect(result.map((user) => user.email)).toEqual(['ana@example.com', 'zz+banana@example.com']);
   });
 
+  it('matches LIKE wildcards literally instead of interpreting them as patterns', async () => {
+    await Promise.all([
+      createUser(userRepository, {
+        email: 'discount@example.com',
+        name: '50% Off',
+      }),
+      createUser(userRepository, {
+        email: 'ana@example.com',
+        name: 'Ana',
+      }),
+      createUser(userRepository, {
+        email: 'underscore@example.com',
+        name: 'a_b',
+      }),
+    ]);
+
+    // A bare `%` used to return the whole directory. It now only matches the literal character,
+    // so a single user comes back instead of all three.
+    const percentOnly = await usersService.search('%');
+    expect(percentOnly.map((user) => user.name)).toEqual(['50% Off']);
+
+    // `_` must not act as a single-character wildcard either.
+    const underscoreOnly = await usersService.search('_');
+    expect(underscoreOnly.map((user) => user.name)).toEqual(['a_b']);
+
+    const percentMatches = await usersService.search('50%');
+    expect(percentMatches.map((user) => user.name)).toEqual(['50% Off']);
+  });
+
   it('returns at most 20 users', async () => {
     await Promise.all(
       Array.from({ length: 25 }, (_, index) =>


### PR DESCRIPTION
Cierra parte de #95.

### Decisión sobre el directorio de usuarios
`GET /api/users` sigue devolviendo el directorio completo, email incluido, a cualquier usuario autenticado. Es una decisión **deliberada**, no un descuido: el selector de participantes necesita la lista completa y el email es lo que desambigua a personas con el mismo nombre. El frontend carga el directorio y filtra en local (`useParticipantsCombobox`).

Es aceptable **solo mientras el registro siga limitado al círculo de amigos** para el que se hizo la app. Esa condición de caducidad queda escrita en dos sitios del código: la descripción Swagger del endpoint (visible en `/api/docs`) y el JSDoc de `UsersService.findAll()`. Cuando deje de cumplirse —el registro se abre, o el directorio pasa de unos cientos de usuarios— hay que migrar a búsqueda server-side; queda una issue de seguimiento para eso.

Se descartó borrar `/users/search` por no tener consumidores: expone estrictamente menos que `GET /users`, y es el camino de migración.

### Validación de `/users/search`
- Nuevo `SearchUsersQueryDto`: `q` obligatorio, trim previo, `MinLength(2)`, `MaxLength(100)`. `q` ausente, vacío, solo espacios, de 1 carácter o de más de 100 → `400` (antes: `q` ausente construía literalmente `ILIKE '%undefined%'`).
- Los comodines `%`, `_` y `\` se escapan antes de la `ILIKE`, así que se buscan literalmente. Antes, `?q=%` devolvía el directorio entero y habría saltado cualquier mínimo de caracteres.
- **Cambio de comportamiento a tener en cuenta:** al pasar de `@Query('q')` a `@Query() dto`, el `forbidNonWhitelisted: true` global hace que cualquier query param desconocido en `/users/search` devuelva ahora `400`.

### Tests
- Unit: escapado de `%`, `_`, `\` y combinaciones.
- Integración (Postgres real): `search('%')` y `search('_')` pasan de devolver el directorio a devolver solo las coincidencias literales.
- E2E nuevo (`users-search.e2e-spec.ts`): los `400` solo existen a nivel HTTP porque los produce la `ValidationPipe`; cubre los 5 casos de rechazo, el param desconocido, el 401 y los casos válidos.

### Verificación
`check:backend` en verde (lint + 158 unit + 32 int + 49 e2e) y `pnpm -r build` compila. Schema Swagger comprobado: `q` sale `required` con `minLength: 2` / `maxLength: 100` y el `400` documentado.

Sin cambios en el frontend.