### PR TITLE
fix(backend): registrar RequestContextService una sola vez en un módulo global (#97)

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -17,7 +17,7 @@ import { AdminModule } from './modules/admin/admin.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { envValidationSchema } from './config/env.validation';
 import { CorrelationMiddleware } from './common/middleware/correlation.middleware';
-import { RequestContextService } from './common/request-context/request-context.service';
+import { RequestContextModule } from './common/request-context/request-context.module';
 
 @Module({
   imports: [
@@ -52,6 +52,7 @@ import { RequestContextService } from './common/request-context/request-context.
       validationSchema: envValidationSchema,
       validationOptions: { abortEarly: false },
     }),
+    RequestContextModule,
     ScheduleModule.forRoot(),
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 100 }]),
     // TypeORM con configuración async para usar ConfigService
@@ -67,8 +68,7 @@ import { RequestContextService } from './common/request-context/request-context.
     AdminModule,
   ],
   controllers: [AppController, HealthController],
-  providers: [AppService, { provide: APP_GUARD, useClass: ThrottlerGuard }, RequestContextService],
-  exports: [RequestContextService],
+  providers: [AppService, { provide: APP_GUARD, useClass: ThrottlerGuard }],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {

--- a/apps/backend/src/common/request-context/request-context.module.ts
+++ b/apps/backend/src/common/request-context/request-context.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { RequestContextService } from './request-context.service';
+
+/**
+ * Registers the AsyncLocalStorage wrapper once for the whole app. The middleware that writes the
+ * correlation id and the services that read it must share a single instance: providing the service
+ * in more than one module makes Nest instantiate it per module, and the stored context is lost.
+ */
+@Global()
+@Module({
+  providers: [RequestContextService],
+  exports: [RequestContextService],
+})
+export class RequestContextModule {}

--- a/apps/backend/src/modules/transactions/transactions.module.ts
+++ b/apps/backend/src/modules/transactions/transactions.module.ts
@@ -6,12 +6,13 @@ import { TransactionPaginationService } from './services/transaction-pagination.
 import { TransactionsController, EventTransactionsController } from './transactions.controller';
 import { Transaction } from './entities/transaction.entity';
 import { Event } from '../events/entities/event.entity';
-import { RequestContextService } from '../../common/request-context/request-context.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Transaction, Event])],
   controllers: [EventTransactionsController, TransactionsController],
-  providers: [TransactionsService, ParticipantValidationService, TransactionPaginationService, RequestContextService],
+  // RequestContextService is not declared here on purpose: it lives in the global RequestContextModule
+  // so the middleware and this module's services share the same AsyncLocalStorage instance.
+  providers: [TransactionsService, ParticipantValidationService, TransactionPaginationService],
   exports: [TransactionsService],
 })
 export class TransactionsModule {}

--- a/apps/backend/test/request-context.int-spec.ts
+++ b/apps/backend/test/request-context.int-spec.ts
@@ -1,0 +1,115 @@
+import { ExecutionContext, INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthGuard } from '@nestjs/passport';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { RequestContextModule } from '../src/common/request-context/request-context.module';
+import { RequestContextService } from '../src/common/request-context/request-context.service';
+import type { AuthenticatedUser } from '../src/common/types/authenticated-user.type';
+import { EventsModule } from '../src/modules/events/events.module';
+import { USER_ROLE } from '../src/modules/users/user-role.constants';
+import { TransactionsModule } from '../src/modules/transactions/transactions.module';
+import { TransactionsService } from '../src/modules/transactions/transactions.service';
+import { applyAppTestConfig } from './utils/test-app-config';
+
+/**
+ * Guards the wiring of RequestContextService: the middleware writes the correlation id into an
+ * AsyncLocalStorage, and a service must read it back from the very same instance. Providing the
+ * service in more than one module used to create two stores, leaving `correlationId` undefined in
+ * every log line that reported it.
+ */
+describe('Request context propagation (integration)', () => {
+  const EVENT_ID = '00000000-0000-0000-0000-000000000001';
+
+  const testUser: AuthenticatedUser = {
+    id: '00000000-0000-0000-0000-0000000000aa',
+    email: 'context@test.com',
+    role: USER_ROLE,
+  };
+
+  let app: INestApplication;
+  let transactionsService: TransactionsService;
+  /** The instance Nest injected into the service, which is what the log lines actually read. */
+  let injectedContext: RequestContextService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest<{ user: AuthenticatedUser }>();
+          req.user = testUser;
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    applyAppTestConfig(app);
+    await app.init();
+
+    transactionsService = app.get(TransactionsService);
+    injectedContext = Reflect.get(transactionsService, 'requestContext') as RequestContextService;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  /**
+   * Runs a request against a real guarded route and returns the correlation id the service saw
+   * while handling it. The service method is stubbed so the test needs no database rows.
+   */
+  const captureCorrelationIdDuringRequest = async (correlationId?: string): Promise<string | undefined> => {
+    let observed: string | undefined;
+
+    jest.spyOn(transactionsService, 'findByEvent').mockImplementation(() => {
+      observed = injectedContext.correlationId;
+      return Promise.resolve([]);
+    });
+
+    const httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+    const pendingRequest = request(httpServer).get(`/api/events/${EVENT_ID}/transactions`);
+
+    if (correlationId !== undefined) {
+      void pendingRequest.set('X-Correlation-Id', correlationId);
+    }
+
+    const response = await pendingRequest.expect(200);
+    expect(response.headers['x-correlation-id']).toBeDefined();
+
+    return observed;
+  };
+
+  it('is declared by no module other than the global RequestContextModule', () => {
+    // Re-declaring the provider anywhere gives that module a private AsyncLocalStorage, which is
+    // how the correlation id used to get lost between the middleware and the service.
+    const declaringModules = [AppModule, EventsModule, TransactionsModule].filter((module) => {
+      const providers = (Reflect.getMetadata('providers', module) as unknown[] | undefined) ?? [];
+      return providers.includes(RequestContextService);
+    });
+
+    expect(declaringModules).toEqual([]);
+    expect(Reflect.getMetadata('providers', RequestContextModule)).toContain(RequestContextService);
+  });
+
+  it('exposes the X-Correlation-Id header value inside the service handling the request', async () => {
+    const correlationId = 'fixed-correlation-id-for-test';
+
+    const observed = await captureCorrelationIdDuringRequest(correlationId);
+
+    expect(observed).toBe(correlationId);
+  });
+
+  it('falls back to a generated correlation id when the header is absent', async () => {
+    const observed = await captureCorrelationIdDuringRequest();
+
+    expect(observed).toEqual(expect.any(String));
+  });
+});


### PR DESCRIPTION
Closes #97

## Qué problema resuelve
`RequestContextService` (envuelve un `AsyncLocalStorage`) estaba registrado como provider en dos módulos (`AppModule` y `TransactionsModule`), así que Nest creaba dos instancias independientes con dos `AsyncLocalStorage` distintos: el middleware que escribe el correlation id usaba una, y `TransactionsService` leía de la otra. Resultado: `this.requestContext.correlationId` era siempre `undefined` en todos los logs de error de `TransactionsService`.

## Cambios
| Cambio | Razón |
|---|---|
| Nuevo `RequestContextModule` (`@Global()`) que provee y exporta `RequestContextService` | Registrar el servicio una única vez como singleton compartido por toda la app |
| `AppModule` importa `RequestContextModule`; se quitan el provider y el export duplicados de `RequestContextService` | Evitar que `AppModule` siga instanciando su propia copia |
| `TransactionsModule` deja de declarar `RequestContextService` como provider propio | La instancia le llega ahora del módulo global, la misma que usa el middleware |
| Nuevo `apps/backend/test/request-context.int-spec.ts` (3 casos) | Verifica que el servicio no se declara en ningún módulo salvo el global, y que el valor de `X-Correlation-Id` llega intacto al servicio dentro de una request real |

## Verificación
- `pnpm --filter @friends/backend lint` — verde
- `pnpm --filter @friends/backend test:all` (158 unit + 35 int + 49 e2e, incluyendo los 3 nuevos) — verde
- `pnpm -r build` — verde
- Los 3 tests nuevos se verificaron en rojo contra el código anterior (dos instancias) y en verde con el fix, confirmando que cubren la regresión real.
