### PR TITLE
test(backend): cover the participant replacement machinery with unit and e2e tests (#98)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,7 @@
     "test": "NODE_ENV=test jest --config ./test/jest.unit.json",
     "test:unit": "NODE_ENV=test jest --config ./test/jest.unit.json",
     "test:watch": "NODE_ENV=test jest --config ./test/jest.unit.json --watch",
-    "test:run": "NODE_ENV=test jest --config ./test/jest.unit.json --runInBand",
+    "test:run": "NODE_ENV=test jest --config ./test/jest.unit.json --runInBand --coverage",
     "test:int": "NODE_ENV=test jest --config ./test/jest.integration.json --runInBand",
     "test:e2e": "NODE_ENV=test jest --config ./test/jest.e2e.json --runInBand",
     "test:all": "pnpm test:run && pnpm test:int && pnpm test:e2e",

--- a/apps/backend/src/modules/events/services/event-participants.service.spec.ts
+++ b/apps/backend/src/modules/events/services/event-participants.service.spec.ts
@@ -1,8 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { In } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
+import { EntityManager, In } from 'typeorm';
 import { User } from '../../users/user.entity';
-import { Event } from '../entities/event.entity';
+import { Event, EventParticipant } from '../entities/event.entity';
+import { Transaction } from '../../transactions/entities/transaction.entity';
+import { ParticipantReplacementDto } from '../dto/participant-replacement.dto';
 import { EventParticipantsService } from './event-participants.service';
 
 const makeUser = (id: string): User =>
@@ -11,7 +14,34 @@ const makeUser = (id: string): User =>
 const makeEvent = (participants: Event['participants']): Event =>
   ({ id: 'evt', participants }) as unknown as Event;
 
-describe('EventParticipantsService.enrichParticipants', () => {
+interface QueryBuilderDouble {
+  update: jest.Mock;
+  set: jest.Mock;
+  where: jest.Mock;
+  andWhere: jest.Mock;
+  execute: jest.Mock;
+}
+
+/** Chainable query builder double: every step returns itself except execute(). */
+const makeQueryBuilder = (affected: number | undefined = 1): QueryBuilderDouble => {
+  const builder: QueryBuilderDouble = {
+    update: jest.fn(() => builder),
+    set: jest.fn(() => builder),
+    where: jest.fn(() => builder),
+    andWhere: jest.fn(() => builder),
+    execute: jest.fn().mockResolvedValue({ affected }),
+  };
+
+  return builder;
+};
+
+const makeManager = (builder: QueryBuilderDouble) => {
+  const getRepository = jest.fn(() => ({ createQueryBuilder: () => builder }));
+
+  return { manager: { getRepository } as unknown as EntityManager, getRepository };
+};
+
+describe('EventParticipantsService', () => {
   let service: EventParticipantsService;
   let userRepository: { find: jest.Mock };
 
@@ -31,81 +61,372 @@ describe('EventParticipantsService.enrichParticipants', () => {
     service = module.get<EventParticipantsService>(EventParticipantsService);
   });
 
-  it('makes a single batch query for multiple events', async () => {
-    const u1 = makeUser('u1');
-    const u2 = makeUser('u2');
-    userRepository.find.mockResolvedValue([u1, u2]);
+  describe('enrichParticipants', () => {
+    it('makes a single batch query for multiple events', async () => {
+      const u1 = makeUser('u1');
+      const u2 = makeUser('u2');
+      userRepository.find.mockResolvedValue([u1, u2]);
 
-    const events = [
-      makeEvent([{ type: 'user', id: 'u1' }]),
-      makeEvent([{ type: 'user', id: 'u2' }]),
-    ];
+      const events = [makeEvent([{ type: 'user', id: 'u1' }]), makeEvent([{ type: 'user', id: 'u2' }])];
 
-    await service.enrichParticipants(events);
+      await service.enrichParticipants(events);
 
-    expect(userRepository.find).toHaveBeenCalledTimes(1);
-    expect(userRepository.find).toHaveBeenCalledWith({
-      where: { id: In(['u1', 'u2']) },
+      expect(userRepository.find).toHaveBeenCalledTimes(1);
+      expect(userRepository.find).toHaveBeenCalledWith({
+        where: { id: In(['u1', 'u2']) },
+      });
+    });
+
+    it('deduplicates user IDs across events', async () => {
+      userRepository.find.mockResolvedValue([makeUser('u1')]);
+
+      const events = [makeEvent([{ type: 'user', id: 'u1' }]), makeEvent([{ type: 'user', id: 'u1' }])];
+
+      await service.enrichParticipants(events);
+
+      const calledWith = (userRepository.find.mock.calls[0] as unknown[])[0] as { where: { id: ReturnType<typeof In> } };
+      const ids = (calledWith.where.id as unknown as { _value: string[] })._value;
+      expect(ids).toHaveLength(1);
+      expect(ids).toContain('u1');
+    });
+
+    it('maps name, email and avatar onto matching participants', async () => {
+      const u1 = makeUser('u1');
+      userRepository.find.mockResolvedValue([u1]);
+
+      const event = makeEvent([{ type: 'user', id: 'u1' }]);
+      await service.enrichParticipants(event);
+
+      expect(event.participants[0]).toMatchObject({
+        type: 'user',
+        id: 'u1',
+        name: u1.name,
+        email: u1.email,
+        avatar: u1.avatar,
+      });
+    });
+
+    it('preserves contributionTarget after enrichment', async () => {
+      userRepository.find.mockResolvedValue([makeUser('u1')]);
+
+      const event = makeEvent([{ type: 'user', id: 'u1', contributionTarget: 150 }]);
+      await service.enrichParticipants(event);
+
+      expect((event.participants[0] as { contributionTarget?: number }).contributionTarget).toBe(150);
+    });
+
+    it('leaves guest and pot participants untouched', async () => {
+      userRepository.find.mockResolvedValue([makeUser('u1')]);
+
+      const guest = { type: 'guest', id: 'g1', name: 'Guest' } as const;
+      const pot = { type: 'pot', id: '0' } as const;
+      const event = makeEvent([{ type: 'user', id: 'u1' }, guest, pot]);
+
+      await service.enrichParticipants(event);
+
+      expect(event.participants[1]).toEqual(guest);
+      expect(event.participants[2]).toEqual(pot);
+    });
+
+    it('skips the DB query when there are no user participants', async () => {
+      const event = makeEvent([
+        { type: 'guest', id: 'g1', name: 'Guest' },
+        { type: 'pot', id: '0' },
+      ]);
+
+      await service.enrichParticipants(event);
+
+      expect(userRepository.find).not.toHaveBeenCalled();
+    });
+
+    it('does not propagate errors from the repository', async () => {
+      userRepository.find.mockRejectedValue(new Error('DB down'));
+
+      const event = makeEvent([{ type: 'user', id: 'u1' }]);
+
+      await expect(service.enrichParticipants(event)).resolves.toBeUndefined();
     });
   });
 
-  it('deduplicates user IDs across events', async () => {
-    userRepository.find.mockResolvedValue([makeUser('u1')]);
+  describe('normalizeParticipants', () => {
+    describe('empty input', () => {
+      it('throws when undefined and empty input is not allowed (create)', () => {
+        expect(() => service.normalizeParticipants(undefined, false)).toThrow(BadRequestException);
+      });
 
-    const events = [
-      makeEvent([{ type: 'user', id: 'u1' }]),
-      makeEvent([{ type: 'user', id: 'u1' }]),
-    ];
+      it('throws when the array is empty and empty input is not allowed (create)', () => {
+        expect(() => service.normalizeParticipants([], false)).toThrow('participants must be a non-empty array');
+      });
 
-    await service.enrichParticipants(events);
+      it('returns undefined when undefined and empty input is allowed (update)', () => {
+        expect(service.normalizeParticipants(undefined, true)).toBeUndefined();
+      });
 
-    const calledWith = (userRepository.find.mock.calls[0] as unknown[])[0] as { where: { id: ReturnType<typeof In> } };
-    const ids = (calledWith.where.id as unknown as { _value: string[] })._value;
-    expect(ids).toHaveLength(1);
-    expect(ids).toContain('u1');
-  });
+      it('returns undefined when the array is empty and empty input is allowed (update)', () => {
+        expect(service.normalizeParticipants([], true)).toBeUndefined();
+      });
 
-  it('maps name, email and avatar onto matching participants', async () => {
-    const u1 = makeUser('u1');
-    userRepository.find.mockResolvedValue([u1]);
+      it('defaults to disallowing empty input', () => {
+        expect(() => service.normalizeParticipants(undefined)).toThrow(BadRequestException);
+      });
+    });
 
-    const event = makeEvent([{ type: 'user', id: 'u1' }]);
-    await service.enrichParticipants(event);
+    it('throws when the input is not an array', () => {
+      const notAnArray = { type: 'user', id: 'u1' } as unknown as unknown[];
 
-    expect(event.participants[0]).toMatchObject({
-      type: 'user',
-      id: 'u1',
-      name: u1.name,
-      email: u1.email,
-      avatar: u1.avatar,
+      expect(() => service.normalizeParticipants(notAnArray)).toThrow('participants must be an array');
+    });
+
+    describe('user participants', () => {
+      it('keeps only type and id, stripping client-supplied name, email and avatar', () => {
+        const result = service.normalizeParticipants([
+          { type: 'user', id: 'u1', name: 'Spoofed', email: 'spoofed@example.com', avatar: 'https://spoofed' },
+        ]);
+
+        expect(result).toEqual([{ type: 'user', id: 'u1' }]);
+      });
+
+      it.each([
+        ['missing', { type: 'user' }],
+        ['not a string', { type: 'user', id: 42 }],
+        ['blank', { type: 'user', id: '   ' }],
+      ])('throws when the id is %s', (_case, participant) => {
+        expect(() => service.normalizeParticipants([participant])).toThrow(
+          'participants[0].id is required for user participant',
+        );
+      });
+    });
+
+    describe('guest participants', () => {
+      it('keeps type, id and name, stripping extra properties', () => {
+        const result = service.normalizeParticipants([
+          { type: 'guest', id: 'g1', name: 'Guest One', email: 'guest@example.com' },
+        ]);
+
+        expect(result).toEqual([{ type: 'guest', id: 'g1', name: 'Guest One' }]);
+      });
+
+      it('throws when the id is blank', () => {
+        expect(() => service.normalizeParticipants([{ type: 'guest', id: ' ', name: 'Guest' }])).toThrow(
+          'participants[0].id is required for guest participant',
+        );
+      });
+
+      it.each([
+        ['missing', { type: 'guest', id: 'g1' }],
+        ['not a string', { type: 'guest', id: 'g1', name: 7 }],
+        ['blank', { type: 'guest', id: 'g1', name: '  ' }],
+      ])('throws when the name is %s', (_case, participant) => {
+        expect(() => service.normalizeParticipants([participant])).toThrow(
+          'participants[0].name is required for guest participant',
+        );
+      });
+    });
+
+    describe('pot participants', () => {
+      it('always normalizes the pot to the reserved id 0', () => {
+        const result = service.normalizeParticipants([{ type: 'pot', id: 'whatever', name: 'Pot' }]);
+
+        expect(result).toEqual([{ type: 'pot', id: '0' }]);
+      });
+    });
+
+    describe('invalid entries', () => {
+      it.each([
+        ['an unknown type', { type: 'ghost', id: 'x' }, "participants[0].type must be one of 'user'|'guest'|'pot'"],
+        ['a missing type', { id: 'x' }, 'participants[0].type is required'],
+        ['a non-object entry', 'not-an-object', 'participants[0].type is required'],
+        ['a null entry', null, 'participants[0].type is required'],
+      ])('throws for %s', (_case, participant, message) => {
+        expect(() => service.normalizeParticipants([participant])).toThrow(message);
+      });
+
+      it('reports the index of the offending participant', () => {
+        expect(() =>
+          service.normalizeParticipants([{ type: 'pot', id: '0' }, { type: 'guest', id: 'g1' }]),
+        ).toThrow('participants[1].name is required for guest participant');
+      });
+    });
+
+    describe.each([
+      ['user', (extra: Record<string, unknown>) => ({ type: 'user', id: 'u1', ...extra })],
+      ['guest', (extra: Record<string, unknown>) => ({ type: 'guest', id: 'g1', name: 'Guest', ...extra })],
+    ])('contributionTarget on %s participants', (_type, build) => {
+      it('keeps a positive target', () => {
+        const result = service.normalizeParticipants([build({ contributionTarget: 120.5 })]);
+
+        expect(result?.[0]).toMatchObject({ contributionTarget: 120.5 });
+      });
+
+      it('keeps a zero target', () => {
+        const result = service.normalizeParticipants([build({ contributionTarget: 0 })]);
+
+        expect(result?.[0]).toMatchObject({ contributionTarget: 0 });
+      });
+
+      it.each([
+        ['undefined', undefined],
+        ['null', null],
+      ])('omits the key entirely when the target is %s', (_case, target) => {
+        const result = service.normalizeParticipants([build({ contributionTarget: target })]);
+
+        expect(result?.[0]).not.toHaveProperty('contributionTarget');
+      });
+
+      it.each([
+        ['a string', '100', 'must be a number or undefined'],
+        ['a boolean', true, 'must be a number or undefined'],
+        ['NaN', Number.NaN, 'must be finite'],
+        ['Infinity', Number.POSITIVE_INFINITY, 'must be finite'],
+        ['negative', -1, 'must be >= 0'],
+      ])('throws when the target is %s', (_case, target, message) => {
+        expect(() => service.normalizeParticipants([build({ contributionTarget: target })])).toThrow(
+          `participants[0].contributionTarget ${message}`,
+        );
+      });
     });
   });
 
-  it('preserves contributionTarget after enrichment', async () => {
-    userRepository.find.mockResolvedValue([makeUser('u1')]);
+  describe('validateParticipantReplacements', () => {
+    const guest: EventParticipant = { type: 'guest', id: 'g1', name: 'Guest One' };
+    const member: EventParticipant = { type: 'user', id: 'u-member' };
+    const originalParticipants: EventParticipant[] = [member, guest];
+    const nextParticipants: EventParticipant[] = [member, { type: 'user', id: 'u-new' }];
 
-    const event = makeEvent([{ type: 'user', id: 'u1', contributionTarget: 150 }]);
-    await service.enrichParticipants(event);
+    const validate = (
+      replacements: ParticipantReplacementDto[] | undefined,
+      next: EventParticipant[] | undefined = nextParticipants,
+      original: EventParticipant[] = originalParticipants,
+    ) => service.validateParticipantReplacements(original, next, replacements);
 
-    expect((event.participants[0] as { contributionTarget?: number }).contributionTarget).toBe(150);
+    it('returns an empty list when no replacements are provided, without requiring participants', () => {
+      expect(service.validateParticipantReplacements(originalParticipants, undefined, undefined)).toEqual([]);
+      expect(service.validateParticipantReplacements(originalParticipants, undefined, [])).toEqual([]);
+    });
+
+    it('throws when replacements are used without providing participants', () => {
+      expect(() =>
+        service.validateParticipantReplacements(originalParticipants, undefined, [
+          { fromGuestId: 'g1', toUserId: 'u-new' },
+        ]),
+      ).toThrow('participants must be provided when participantReplacements are used');
+    });
+
+    it('returns the trimmed replacement list on a valid replacement', () => {
+      expect(validate([{ fromGuestId: '  g1  ', toUserId: ' u-new ' }])).toEqual([
+        { fromGuestId: 'g1', toUserId: 'u-new' },
+      ]);
+    });
+
+    it.each([
+      ['fromGuestId', { fromGuestId: '   ', toUserId: 'u-new' }, 'participantReplacements[0].fromGuestId is required'],
+      ['toUserId', { fromGuestId: 'g1', toUserId: '   ' }, 'participantReplacements[0].toUserId is required'],
+    ])('throws when %s is blank', (_case, replacement, message) => {
+      expect(() => validate([replacement])).toThrow(message);
+    });
+
+    it('throws when the same guest is replaced twice', () => {
+      const original = [...originalParticipants];
+      const next: EventParticipant[] = [member, { type: 'user', id: 'u-new' }, { type: 'user', id: 'u-other' }];
+
+      expect(() =>
+        validate(
+          [
+            { fromGuestId: 'g1', toUserId: 'u-new' },
+            { fromGuestId: 'g1', toUserId: 'u-other' },
+          ],
+          next,
+          original,
+        ),
+      ).toThrow('Duplicate replacement source guest id: g1');
+    });
+
+    it('throws when the same user is the target of two replacements', () => {
+      const original: EventParticipant[] = [member, guest, { type: 'guest', id: 'g2', name: 'Guest Two' }];
+
+      expect(() =>
+        validate(
+          [
+            { fromGuestId: 'g1', toUserId: 'u-new' },
+            { fromGuestId: 'g2', toUserId: 'u-new' },
+          ],
+          nextParticipants,
+          original,
+        ),
+      ).toThrow('Duplicate replacement destination user id: u-new');
+    });
+
+    it('throws when the source guest does not exist in the event', () => {
+      expect(() => validate([{ fromGuestId: 'g-unknown', toUserId: 'u-new' }])).toThrow(
+        'Guest participant g-unknown does not exist in the event',
+      );
+    });
+
+    it('throws when the destination user already participates in the event', () => {
+      expect(() => validate([{ fromGuestId: 'g1', toUserId: member.id }])).toThrow(
+        `User ${member.id} already participates in the event and cannot be used as replacement target`,
+      );
+    });
+
+    it('throws when the destination user is missing from the updated participants', () => {
+      expect(() => validate([{ fromGuestId: 'g1', toUserId: 'u-absent' }])).toThrow(
+        'Replacement target user u-absent must exist in updated participants',
+      );
+    });
+
+    it('throws when the source guest is still present in the updated participants', () => {
+      const next: EventParticipant[] = [...nextParticipants, guest];
+
+      expect(() => validate([{ fromGuestId: 'g1', toUserId: 'u-new' }], next)).toThrow(
+        'Replacement source guest g1 must be removed from updated participants',
+      );
+    });
   });
 
-  it('skips the DB query when there are no user participants', async () => {
-    const event = makeEvent([
-      { type: 'guest', id: 'g1', name: 'Guest' },
-      { type: 'pot', id: '0' },
-    ]);
+  describe('applyParticipantReplacements', () => {
+    it('does not touch the database when there are no replacements', async () => {
+      const { manager, getRepository } = makeManager(makeQueryBuilder());
 
-    await service.enrichParticipants(event);
+      await service.applyParticipantReplacements(manager, 'evt-1', []);
 
-    expect(userRepository.find).not.toHaveBeenCalled();
-  });
+      expect(getRepository).not.toHaveBeenCalled();
+    });
 
-  it('does not propagate errors from the repository', async () => {
-    userRepository.find.mockRejectedValue(new Error('DB down'));
+    it('issues a scoped update for a single replacement', async () => {
+      const builder = makeQueryBuilder(3);
+      const { manager, getRepository } = makeManager(builder);
 
-    const event = makeEvent([{ type: 'user', id: 'u1' }]);
+      await service.applyParticipantReplacements(manager, 'evt-1', [{ fromGuestId: 'g1', toUserId: 'u-new' }]);
 
-    await expect(service.enrichParticipants(event)).resolves.toBeUndefined();
+      expect(getRepository).toHaveBeenCalledWith(Transaction);
+      expect(builder.update).toHaveBeenCalledWith(Transaction);
+      expect(builder.set).toHaveBeenCalledWith({ participantId: 'u-new' });
+      expect(builder.where).toHaveBeenCalledWith('event_id = :eventId', { eventId: 'evt-1' });
+      expect(builder.andWhere).toHaveBeenCalledWith('participant_id = :fromGuestId', { fromGuestId: 'g1' });
+      expect(builder.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('issues one update per replacement, in order', async () => {
+      const builder = makeQueryBuilder(1);
+      const { manager } = makeManager(builder);
+
+      await service.applyParticipantReplacements(manager, 'evt-1', [
+        { fromGuestId: 'g1', toUserId: 'u-one' },
+        { fromGuestId: 'g2', toUserId: 'u-two' },
+      ]);
+
+      const setPayloads = (builder.set.mock.calls as Array<[Record<string, unknown>]>).map((call) => call[0]);
+
+      expect(builder.execute).toHaveBeenCalledTimes(2);
+      expect(setPayloads).toEqual([{ participantId: 'u-one' }, { participantId: 'u-two' }]);
+    });
+
+    it('tolerates a driver that does not report the affected row count', async () => {
+      const { manager } = makeManager(makeQueryBuilder(undefined));
+
+      await expect(
+        service.applyParticipantReplacements(manager, 'evt-1', [{ fromGuestId: 'g1', toUserId: 'u-new' }]),
+      ).resolves.toBeUndefined();
+    });
   });
 });

--- a/apps/backend/test/events-participant-replacements.e2e-spec.ts
+++ b/apps/backend/test/events-participant-replacements.e2e-spec.ts
@@ -1,0 +1,233 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import request from 'supertest';
+import { Repository } from 'typeorm';
+import { AppModule } from '../src/app.module';
+import { Event } from '../src/modules/events/entities/event.entity';
+import { EventParticipantsService } from '../src/modules/events/services/event-participants.service';
+import { Transaction } from '../src/modules/transactions/entities/transaction.entity';
+import { User } from '../src/modules/users/user.entity';
+import { applyAppTestConfig } from './utils/test-app-config';
+import { createEvent, createTransaction, createUser } from './utils/test-factories';
+import { buildAuthHeader, getDataObjectFromBody } from './utils/test-http-helpers';
+
+const GUEST_ID = 'g-1';
+
+describe('Event participant replacements (e2e)', () => {
+  let app: INestApplication;
+  let jwtService: JwtService;
+  let userRepository: Repository<User>;
+  let eventRepository: Repository<Event>;
+  let transactionRepository: Repository<Transaction>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    applyAppTestConfig(app);
+    await app.init();
+
+    jwtService = app.get(JwtService);
+    userRepository = app.get<Repository<User>>(getRepositoryToken(User));
+    eventRepository = app.get<Repository<Event>>(getRepositoryToken(Event));
+    transactionRepository = app.get<Repository<Transaction>>(getRepositoryToken(Transaction));
+  });
+
+  beforeEach(async () => {
+    await transactionRepository.createQueryBuilder().delete().from(Transaction).execute();
+    await eventRepository.createQueryBuilder().delete().from(Event).execute();
+    await userRepository.createQueryBuilder().delete().from(User).execute();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const httpServer = () => app.getHttpServer() as Parameters<typeof request>[0];
+
+  /**
+   * Owner + a guest with two transactions, plus a control transaction for the same guest id
+   * living in a different event: replacements must never leak across events.
+   */
+  async function seedScenario() {
+    const owner = await createUser(userRepository, { email: 'owner@example.com', name: 'Owner' });
+    const destination = await createUser(userRepository, { email: 'destination@example.com', name: 'Destination' });
+
+    const createResponse = await request(httpServer())
+      .post('/api/events')
+      .set('Authorization', buildAuthHeader(jwtService, owner))
+      .send({
+        title: 'Replacement Event',
+        participants: [{ type: 'guest', id: GUEST_ID, name: 'Guest One' }],
+      })
+      .expect(201);
+
+    const eventId = String(getDataObjectFromBody(createResponse.body).id);
+
+    const guestTransactions = await Promise.all([
+      createTransaction(transactionRepository, {
+        title: 'Guest contribution',
+        paymentType: 'contribution',
+        amount: 50,
+        participantId: GUEST_ID,
+        eventId,
+      }),
+      createTransaction(transactionRepository, {
+        title: 'Guest expense',
+        paymentType: 'expense',
+        amount: 20,
+        participantId: GUEST_ID,
+        eventId,
+      }),
+    ]);
+
+    const ownerTransaction = await createTransaction(transactionRepository, {
+      title: 'Owner contribution',
+      paymentType: 'contribution',
+      amount: 30,
+      participantId: owner.id,
+      eventId,
+    });
+
+    const otherEvent = await createEvent(eventRepository, {
+      title: 'Untouched Event',
+      participants: [{ type: 'user', id: owner.id }, { type: 'guest', id: GUEST_ID, name: 'Guest One' }],
+    });
+
+    const otherEventTransaction = await createTransaction(transactionRepository, {
+      title: 'Guest expense in another event',
+      paymentType: 'expense',
+      amount: 15,
+      participantId: GUEST_ID,
+      eventId: otherEvent.id,
+    });
+
+    return { owner, destination, eventId, guestTransactions, ownerTransaction, otherEventTransaction };
+  }
+
+  const participantIdOf = async (transactionId: string): Promise<string | undefined> =>
+    (await transactionRepository.findOne({ where: { id: transactionId } }))?.participantId;
+
+  const participantsOf = async (eventId: string) =>
+    (await eventRepository.findOne({ where: { id: eventId } }))?.participants ?? [];
+
+  it('migrates the guest transactions to the destination user and leaves every other transaction alone', async () => {
+    const { owner, destination, eventId, guestTransactions, ownerTransaction, otherEventTransaction } =
+      await seedScenario();
+
+    await request(httpServer())
+      .patch(`/api/events/${eventId}`)
+      .set('Authorization', buildAuthHeader(jwtService, owner))
+      .send({
+        participants: [
+          { type: 'user', id: owner.id },
+          { type: 'user', id: destination.id },
+        ],
+        participantReplacements: [{ fromGuestId: GUEST_ID, toUserId: destination.id }],
+      })
+      .expect(200);
+
+    for (const transaction of guestTransactions) {
+      await expect(participantIdOf(transaction.id)).resolves.toBe(destination.id);
+    }
+
+    await expect(participantIdOf(ownerTransaction.id)).resolves.toBe(owner.id);
+    await expect(participantIdOf(otherEventTransaction.id)).resolves.toBe(GUEST_ID);
+
+    const getResponse = await request(httpServer())
+      .get(`/api/events/${eventId}`)
+      .set('Authorization', buildAuthHeader(jwtService, owner))
+      .expect(200);
+
+    const participants = (getDataObjectFromBody(getResponse.body).participants ?? []) as Array<
+      Record<string, unknown>
+    >;
+
+    expect(participants).not.toContainEqual(expect.objectContaining({ id: GUEST_ID }));
+    expect(participants).toContainEqual(
+      expect.objectContaining({ type: 'user', id: destination.id, name: 'Destination' }),
+    );
+  });
+
+  it('rejects a replacement whose target user is missing from the updated participants and changes nothing', async () => {
+    const { owner, destination, eventId, guestTransactions } = await seedScenario();
+
+    const response = await request(httpServer())
+      .patch(`/api/events/${eventId}`)
+      .set('Authorization', buildAuthHeader(jwtService, owner))
+      .send({
+        participants: [{ type: 'user', id: owner.id }],
+        participantReplacements: [{ fromGuestId: GUEST_ID, toUserId: destination.id }],
+      })
+      .expect(400);
+
+    expect(response.body).toMatchObject({
+      statusCode: 400,
+      path: `/api/events/${eventId}`,
+      method: 'PATCH',
+    });
+
+    for (const transaction of guestTransactions) {
+      await expect(participantIdOf(transaction.id)).resolves.toBe(GUEST_ID);
+    }
+
+    expect(await participantsOf(eventId)).toContainEqual(expect.objectContaining({ type: 'guest', id: GUEST_ID }));
+  });
+
+  it('rolls back the migrated transactions and the event itself when the update fails midway', async () => {
+    const { owner, destination, eventId, guestTransactions } = await seedScenario();
+
+    // There is no foreign key on participant_id, so no realistic query can fail on its own:
+    // inject the failure after the real migration has already run inside the DB transaction.
+    // The value read through the transactional manager proves the UPDATE did happen, so the
+    // assertions below are really observing a rollback and not a migration that never ran.
+    let participantIdInsideTransaction: string | undefined;
+
+    const participantsService = app.get(EventParticipantsService);
+    // `strictBindCallApply` is off in this tsconfig, so bind() widens to any: assert it back.
+    const applyReplacements = participantsService.applyParticipantReplacements.bind(
+      participantsService,
+    ) as EventParticipantsService['applyParticipantReplacements'];
+
+    jest
+      .spyOn(participantsService, 'applyParticipantReplacements')
+      .mockImplementation(async (manager, id, replacements) => {
+        await applyReplacements(manager, id, replacements);
+
+        const migrated = await manager.getRepository(Transaction).findOne({ where: { id: guestTransactions[0].id } });
+        participantIdInsideTransaction = migrated?.participantId;
+
+        throw new Error('injected failure after migration');
+      });
+
+    await request(httpServer())
+      .patch(`/api/events/${eventId}`)
+      .set('Authorization', buildAuthHeader(jwtService, owner))
+      .send({
+        participants: [
+          { type: 'user', id: owner.id },
+          { type: 'user', id: destination.id },
+        ],
+        participantReplacements: [{ fromGuestId: GUEST_ID, toUserId: destination.id }],
+      })
+      .expect(500);
+
+    expect(participantIdInsideTransaction).toBe(destination.id);
+
+    for (const transaction of guestTransactions) {
+      await expect(participantIdOf(transaction.id)).resolves.toBe(GUEST_ID);
+    }
+
+    const participants = await participantsOf(eventId);
+    expect(participants).toContainEqual(expect.objectContaining({ type: 'guest', id: GUEST_ID }));
+    expect(participants).not.toContainEqual(expect.objectContaining({ id: destination.id }));
+  });
+});

--- a/apps/backend/test/jest.unit.json
+++ b/apps/backend/test/jest.unit.json
@@ -13,6 +13,12 @@
       "functions": 55,
       "lines": 50,
       "statements": 50
+    },
+    "./src/modules/events/services/event-participants.service.ts": {
+      "branches": 85,
+      "functions": 90,
+      "lines": 90,
+      "statements": 90
     }
   },
   "testEnvironment": "node"


### PR DESCRIPTION
Relacionado con #98 (no autocierra: el PR va contra `develop`, que no es la rama por defecto)

## Qué problema resuelve

`event-participants.service.ts` — la lógica de normalización y reemplazo de participantes (incluida la migración guest→user de transacciones) — apenas tenía cobertura (26.27% de statements) pese a ser un punto sensible: toca datos de eventos y transacciones dentro de una transacción de BD.

## Cambios

- **Unitarios** (`event-participants.service.spec.ts`): reestructurado en un `describe` por método, con ~55 tests nuevos que cubren `normalizeParticipants`, `validateParticipantReplacements` y `applyParticipantReplacements`.
- **E2E** (`events-participant-replacements.e2e-spec.ts`, nuevo): flujo completo de reemplazo guest→user —
  - happy path con migración de transacciones y verificación de que no hay fuga a otros eventos,
  - reemplazo inválido con 400 y sin efectos secundarios,
  - rollback completo ante un fallo inyectado dentro de la transacción de BD.
- **Cobertura**: `event-participants.service.ts` pasa de 26.27% a 99.15% statements (91.89% branches, 100% funciones, 100% líneas). Se añade un umbral de cobertura por fichero en `jest.unit.json` (90 stmts / 85 branches / 90 funcs / 90 lines) para fijarlo.
- **`test:run` ahora corre con `--coverage`**: sin esto el `coverageThreshold` no se aplicaba ni en `check:backend` ni en CI, así que era decorativo.

## Verificación

- `pnpm check:backend`: lint OK, 213 unit, 35 int, 52 e2e, todo en verde.
- `pnpm -r build`: OK.
- `pnpm lint` (repetido antes de abrir este PR): OK.
