### PR TITLE
refactor(backend): extraer un EventAccessService compartido para deduplicar la lógica de autorización

### DIFF
--- a/apps/backend/src/modules/event-access/event-access.module.ts
+++ b/apps/backend/src/modules/event-access/event-access.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Event } from '../events/entities/event.entity';
+import { EventAccessService } from './event-access.service';
+
+/**
+ * Standalone module so that every consumer of the event access rule imports the same service without
+ * coupling to EventsModule. EventsModule already imports TransactionsModule, so hosting the service
+ * there would force a circular dependency between the two.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([Event])],
+  providers: [EventAccessService],
+  exports: [EventAccessService],
+})
+export class EventAccessModule {}

--- a/apps/backend/src/modules/event-access/event-access.service.spec.ts
+++ b/apps/backend/src/modules/event-access/event-access.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { EventAccessService } from './event-access.service';
+import { Event, EventParticipant, EventStatus } from '../events/entities/event.entity';
+import type { AuthenticatedUser } from '../../common/types/authenticated-user.type';
+
+const adminActor: AuthenticatedUser = { id: 'admin-1', email: 'admin@example.com', role: 'admin' };
+const memberActor: AuthenticatedUser = { id: 'user-1', email: 'user-1@example.com', role: 'user' };
+const outsiderActor: AuthenticatedUser = { id: 'user-2', email: 'user-2@example.com', role: 'user' };
+
+const makeEvent = (participants: EventParticipant[] | undefined): Event =>
+  ({
+    id: 'event-1',
+    title: 'Test Event',
+    status: EventStatus.ACTIVE,
+    participants,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  }) as Event;
+
+describe('EventAccessService', () => {
+  let service: EventAccessService;
+  let eventRepository: { findOne: jest.Mock };
+
+  beforeEach(async () => {
+    eventRepository = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EventAccessService, { provide: getRepositoryToken(Event), useValue: eventRepository }],
+    }).compile();
+
+    service = module.get<EventAccessService>(EventAccessService);
+  });
+
+  describe('isAdmin', () => {
+    it('is true only for the admin role', () => {
+      expect(service.isAdmin(adminActor)).toBe(true);
+      expect(service.isAdmin(memberActor)).toBe(false);
+    });
+  });
+
+  describe('canAccessEvent', () => {
+    it('allows an admin regardless of participation', () => {
+      expect(service.canAccessEvent(makeEvent([]), adminActor)).toBe(true);
+    });
+
+    it('allows a user participant of the event', () => {
+      const event = makeEvent([{ type: 'user', id: memberActor.id }]);
+
+      expect(service.canAccessEvent(event, memberActor)).toBe(true);
+    });
+
+    it('denies a user that is not a participant', () => {
+      const event = makeEvent([{ type: 'user', id: memberActor.id }]);
+
+      expect(service.canAccessEvent(event, outsiderActor)).toBe(false);
+    });
+
+    it('does not count a guest participant sharing the actor id', () => {
+      const event = makeEvent([{ type: 'guest', id: memberActor.id, name: 'Guest' }]);
+
+      expect(service.canAccessEvent(event, memberActor)).toBe(false);
+    });
+
+    it('denies a user when the event has no participants', () => {
+      expect(service.canAccessEvent(makeEvent(undefined), memberActor)).toBe(false);
+      expect(service.canAccessEvent(makeEvent([]), memberActor)).toBe(false);
+    });
+  });
+
+  describe('ensureCanAccessEvent', () => {
+    it('returns silently when access is allowed', () => {
+      const event = makeEvent([{ type: 'user', id: memberActor.id }]);
+
+      expect(() => service.ensureCanAccessEvent(event, memberActor)).not.toThrow();
+    });
+
+    it('throws ForbiddenException naming the event when access is denied', () => {
+      const event = makeEvent([{ type: 'user', id: memberActor.id }]);
+
+      expect(() => service.ensureCanAccessEvent(event, outsiderActor)).toThrow(ForbiddenException);
+      expect(() => service.ensureCanAccessEvent(event, outsiderActor)).toThrow(
+        `Access to event ${event.id} is not allowed`,
+      );
+    });
+  });
+
+  describe('findEvent', () => {
+    it('returns null instead of throwing when the event does not exist', async () => {
+      eventRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findEvent('missing-id')).resolves.toBeNull();
+      expect(eventRepository.findOne).toHaveBeenCalledWith({ where: { id: 'missing-id' } });
+    });
+  });
+
+  describe('findEventOrThrow', () => {
+    it('returns the event when it exists', async () => {
+      const event = makeEvent([]);
+      eventRepository.findOne.mockResolvedValue(event);
+
+      await expect(service.findEventOrThrow(event.id)).resolves.toBe(event);
+    });
+
+    it('throws NotFoundException when the event does not exist', async () => {
+      eventRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findEventOrThrow('missing-id')).rejects.toThrow(NotFoundException);
+      await expect(service.findEventOrThrow('missing-id')).rejects.toThrow('Event with ID missing-id not found');
+    });
+  });
+
+  describe('loadAccessibleEvent', () => {
+    it('returns the event when the actor can access it', async () => {
+      const event = makeEvent([{ type: 'user', id: memberActor.id }]);
+      eventRepository.findOne.mockResolvedValue(event);
+
+      await expect(service.loadAccessibleEvent(event.id, memberActor)).resolves.toBe(event);
+    });
+
+    it('throws NotFoundException before authorizing when the event does not exist', async () => {
+      eventRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.loadAccessibleEvent('missing-id', outsiderActor)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when the actor cannot access the event', async () => {
+      const event = makeEvent([{ type: 'user', id: memberActor.id }]);
+      eventRepository.findOne.mockResolvedValue(event);
+
+      await expect(service.loadAccessibleEvent(event.id, outsiderActor)).rejects.toThrow(ForbiddenException);
+    });
+  });
+});

--- a/apps/backend/src/modules/event-access/event-access.service.ts
+++ b/apps/backend/src/modules/event-access/event-access.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { AuthenticatedUser } from '../../common/types/authenticated-user.type';
+import { Event } from '../events/entities/event.entity';
+import { ADMIN_ROLE } from '../users/user-role.constants';
+
+/**
+ * Single owner of the event access rule: an actor may access an event when it is an admin, or when it
+ * is listed as a participant of type 'user' in the event.
+ *
+ * Every module that needs to authorize event access depends on this service instead of reimplementing
+ * the rule against its own repository, so changing the rule means changing one place only.
+ */
+@Injectable()
+export class EventAccessService {
+  constructor(
+    @InjectRepository(Event)
+    private readonly eventRepository: Repository<Event>,
+  ) {}
+
+  isAdmin(actor: AuthenticatedUser): boolean {
+    return actor.role === ADMIN_ROLE;
+  }
+
+  /**
+   * Whether the actor is allowed to access the given event. Guest participants sharing the actor id
+   * do not grant access: only participants of type 'user' are matched.
+   */
+  canAccessEvent(event: Event, actor: AuthenticatedUser): boolean {
+    if (this.isAdmin(actor)) return true;
+    return (event.participants ?? []).some((p) => p.type === 'user' && p.id === actor.id);
+  }
+
+  /**
+   * Same rule as canAccessEvent, throwing instead of returning false.
+   */
+  ensureCanAccessEvent(event: Event, actor: AuthenticatedUser): void {
+    if (!this.canAccessEvent(event, actor)) {
+      throw new ForbiddenException(`Access to event ${event.id} is not allowed`);
+    }
+  }
+
+  /**
+   * Load an event without authorizing it. Callers that need to report a missing event as something
+   * else (to avoid leaking its existence) use this instead of findEventOrThrow.
+   */
+  async findEvent(eventId: string): Promise<Event | null> {
+    return this.eventRepository.findOne({ where: { id: eventId } });
+  }
+
+  async findEventOrThrow(eventId: string): Promise<Event> {
+    const event = await this.findEvent(eventId);
+    if (!event) {
+      throw new NotFoundException(`Event with ID ${eventId} not found`);
+    }
+    return event;
+  }
+
+  /**
+   * Load an event and authorize the actor against it in one step: 404 when it does not exist,
+   * 403 when the actor cannot access it.
+   */
+  async loadAccessibleEvent(eventId: string, actor: AuthenticatedUser): Promise<Event> {
+    const event = await this.findEventOrThrow(eventId);
+    this.ensureCanAccessEvent(event, actor);
+    return event;
+  }
+}

--- a/apps/backend/src/modules/events/events.module.ts
+++ b/apps/backend/src/modules/events/events.module.ts
@@ -5,12 +5,13 @@ import { EventsController } from './events.controller';
 import { Event } from './entities/event.entity';
 import { User } from '../users/user.entity';
 import { TransactionsModule } from '../transactions/transactions.module';
+import { EventAccessModule } from '../event-access/event-access.module';
 import { EventKPIsService } from './services/event-kpis.service';
 import { EventQueryService } from './services/event-query.service';
 import { EventParticipantsService } from './services/event-participants.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Event, User]), TransactionsModule],
+  imports: [TypeOrmModule.forFeature([Event, User]), TransactionsModule, EventAccessModule],
   controllers: [EventsController],
   providers: [EventsService, EventKPIsService, EventQueryService, EventParticipantsService],
   exports: [EventsService],

--- a/apps/backend/src/modules/events/events.service.spec.ts
+++ b/apps/backend/src/modules/events/events.service.spec.ts
@@ -9,6 +9,7 @@ import { UpdateEventDto } from './dto/update-event.dto';
 import { EventKPIsService } from './services/event-kpis.service';
 import { EventQueryService } from './services/event-query.service';
 import { EventParticipantsService } from './services/event-participants.service';
+import { EventAccessService } from '../event-access/event-access.service';
 import type { AuthenticatedUser } from '../../common/types/authenticated-user.type';
 
 describe('EventsService', () => {
@@ -16,6 +17,7 @@ describe('EventsService', () => {
 
   let mockRepository: {
     find: jest.Mock;
+    findOne: jest.Mock;
     create: jest.Mock;
     save: jest.Mock;
     merge: jest.Mock;
@@ -30,7 +32,6 @@ describe('EventsService', () => {
     save: jest.Mock;
   };
   let mockEventQueryService: {
-    findEventOrThrow: jest.Mock;
     calculateLastModified: jest.Mock;
   };
   let mockEventParticipantsService: {
@@ -77,6 +78,8 @@ describe('EventsService', () => {
   beforeEach(async () => {
     mockRepository = {
       find: jest.fn(),
+      // Consumed by the real EventAccessService below, which loads the event before authorizing it
+      findOne: jest.fn().mockResolvedValue(mockEvent),
       create: jest.fn(),
       save: jest.fn(),
       merge: jest.fn(),
@@ -106,7 +109,6 @@ describe('EventsService', () => {
     });
 
     mockEventQueryService = {
-      findEventOrThrow: jest.fn().mockResolvedValue(mockEvent),
       calculateLastModified: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -128,6 +130,9 @@ describe('EventsService', () => {
           provide: getRepositoryToken(Event),
           useValue: mockRepository,
         },
+        // The real EventAccessService is wired over the mocked repository so these tests keep
+        // exercising the access rule itself, not just the delegation to it.
+        EventAccessService,
         {
           provide: EventQueryService,
           useValue: mockEventQueryService,
@@ -194,13 +199,11 @@ describe('EventsService', () => {
       const result = await service.findOne(mockEvent.id, adminActor);
 
       expect(result).toEqual(mockEvent);
-      expect(mockEventQueryService.findEventOrThrow).toHaveBeenCalledWith(mockEvent.id);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({ where: { id: mockEvent.id } });
     });
 
     it('throws NotFoundException when event does not exist', async () => {
-      mockEventQueryService.findEventOrThrow.mockRejectedValue(
-        new NotFoundException(`Event with ID non-existent-id not found`),
-      );
+      mockRepository.findOne.mockResolvedValue(null);
 
       await expect(service.findOne('non-existent-id', adminActor)).rejects.toThrow(NotFoundException);
     });
@@ -420,9 +423,7 @@ describe('EventsService', () => {
     });
 
     it('throws NotFoundException when event does not exist', async () => {
-      mockEventQueryService.findEventOrThrow.mockRejectedValue(
-        new NotFoundException('Event with ID non-existent-id not found'),
-      );
+      mockRepository.findOne.mockResolvedValue(null);
 
       await expect(service.getKPIs('non-existent-id', adminActor)).rejects.toThrow(NotFoundException);
       expect(mockEventKPIsService.getKPIs).not.toHaveBeenCalled();

--- a/apps/backend/src/modules/events/events.service.ts
+++ b/apps/backend/src/modules/events/events.service.ts
@@ -17,7 +17,7 @@ import { EventKPIsService } from './services/event-kpis.service';
 import { EventQueryService } from './services/event-query.service';
 import { EventParticipantsService } from './services/event-participants.service';
 import { EventKPIsDto } from './dto/event-kpis.dto';
-import { ADMIN_ROLE } from '../users/user-role.constants';
+import { EventAccessService } from '../event-access/event-access.service';
 
 @Injectable()
 export class EventsService {
@@ -26,6 +26,7 @@ export class EventsService {
   constructor(
     @InjectRepository(Event)
     private readonly eventRepository: Repository<Event>,
+    private readonly eventAccessService: EventAccessService,
     private readonly eventQueryService: EventQueryService,
     private readonly eventParticipantsService: EventParticipantsService,
     private readonly eventKPIsService: EventKPIsService,
@@ -46,23 +47,8 @@ export class EventsService {
     return cleanUpdate;
   }
 
-  private isAdmin(actor: AuthenticatedUser): boolean {
-    return actor.role === ADMIN_ROLE;
-  }
-
-  private isUserParticipant(event: Event, userId: string): boolean {
-    return (event.participants ?? []).some((p) => p.type === 'user' && p.id === userId);
-  }
-
-  private ensureCanAccessEvent(event: Event, actor: AuthenticatedUser): void {
-    if (this.isAdmin(actor)) return;
-    if (!this.isUserParticipant(event, actor.id)) {
-      throw new ForbiddenException(`Access to event ${event.id} is not allowed`);
-    }
-  }
-
   private ensureActorParticipant(participants: EventParticipant[], actor: AuthenticatedUser): EventParticipant[] {
-    if (this.isAdmin(actor)) return participants;
+    if (this.eventAccessService.isAdmin(actor)) return participants;
     const hasCurrentUser = participants.some((p) => p.type === 'user' && p.id === actor.id);
     return hasCurrentUser ? participants : [...participants, { type: 'user', id: actor.id }];
   }
@@ -82,9 +68,7 @@ export class EventsService {
         order: { createdAt: 'DESC' },
       });
 
-      if (!this.isAdmin(actor)) {
-        events = events.filter((event) => this.isUserParticipant(event, actor.id));
-      }
+      events = events.filter((event) => this.eventAccessService.canAccessEvent(event, actor));
 
       await this.eventParticipantsService.enrichParticipants(events);
       await this.eventQueryService.calculateLastModified(events);
@@ -104,8 +88,7 @@ export class EventsService {
   async findOne(id: string, actor: AuthenticatedUser): Promise<Event> {
     try {
       this.logger.log(`Fetching event with ID: ${id}`);
-      const event = await this.eventQueryService.findEventOrThrow(id);
-      this.ensureCanAccessEvent(event, actor);
+      const event = await this.eventAccessService.loadAccessibleEvent(id, actor);
 
       await this.eventParticipantsService.enrichParticipants(event);
       await this.eventQueryService.calculateLastModified(event);
@@ -158,8 +141,7 @@ export class EventsService {
     try {
       this.logger.log(`Updating event with ID: ${id}`);
 
-      const event = await this.eventQueryService.findEventOrThrow(id);
-      this.ensureCanAccessEvent(event, actor);
+      const event = await this.eventAccessService.loadAccessibleEvent(id, actor);
 
       const normalizedParticipants = this.eventParticipantsService.normalizeParticipants(updateEventDto.participants, true);
 
@@ -182,7 +164,7 @@ export class EventsService {
             throw new NotFoundException(`Event with ID ${id} not found`);
           }
 
-          this.ensureCanAccessEvent(eventToUpdate, actor);
+          this.eventAccessService.ensureCanAccessEvent(eventToUpdate, actor);
 
           const updatedEvent = transactionalEventRepository.merge(eventToUpdate, cleanUpdate);
           const transactionSavedEvent = await transactionalEventRepository.save(updatedEvent);
@@ -218,8 +200,7 @@ export class EventsService {
     try {
       this.logger.log(`Deleting event with ID: ${id}`);
 
-      const event = await this.eventQueryService.findEventOrThrow(id);
-      this.ensureCanAccessEvent(event, actor);
+      await this.eventAccessService.loadAccessibleEvent(id, actor);
 
       await this.eventRepository.delete(id);
       this.logger.log(`Event ${id} deleted successfully`);
@@ -235,8 +216,7 @@ export class EventsService {
    * Get KPIs for a specific event.
    */
   async getKPIs(eventId: string, actor: AuthenticatedUser): Promise<EventKPIsDto> {
-    const event = await this.eventQueryService.findEventOrThrow(eventId);
-    this.ensureCanAccessEvent(event, actor);
+    await this.eventAccessService.loadAccessibleEvent(eventId, actor);
     return this.eventKPIsService.getKPIs(eventId, actor);
   }
 }

--- a/apps/backend/src/modules/events/services/event-query.service.ts
+++ b/apps/backend/src/modules/events/services/event-query.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Event } from '../entities/event.entity';
@@ -20,14 +20,6 @@ export class EventQueryService {
     @InjectRepository(Event)
     private readonly eventRepository: Repository<Event>,
   ) {}
-
-  async findEventOrThrow(id: string): Promise<Event> {
-    const event = await this.eventRepository.findOne({ where: { id } });
-    if (!event) {
-      throw new NotFoundException(`Event with ID ${id} not found`);
-    }
-    return event;
-  }
 
   /**
    * Calculate lastModified for event(s) as the greatest between event.updatedAt

--- a/apps/backend/src/modules/transactions/services/transaction-pagination.service.spec.ts
+++ b/apps/backend/src/modules/transactions/services/transaction-pagination.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Event } from '../../events/entities/event.entity';
 import { Transaction } from '../entities/transaction.entity';
 import { TransactionPaginationService } from './transaction-pagination.service';
+import { EventAccessService } from '../../event-access/event-access.service';
 
 describe('TransactionPaginationService', () => {
   let service: TransactionPaginationService;
@@ -26,6 +27,9 @@ describe('TransactionPaginationService', () => {
           provide: getRepositoryToken(Transaction),
           useValue: transactionRepository,
         },
+        // The real EventAccessService is wired over the mocked event repository, so eventRepository
+        // still drives the "event does not exist" cases below.
+        EventAccessService,
         {
           provide: getRepositoryToken(Event),
           useValue: eventRepository,

--- a/apps/backend/src/modules/transactions/services/transaction-pagination.service.ts
+++ b/apps/backend/src/modules/transactions/services/transaction-pagination.service.ts
@@ -8,7 +8,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Transaction } from '../entities/transaction.entity';
-import { Event } from '../../events/entities/event.entity';
+import { EventAccessService } from '../../event-access/event-access.service';
 import { PaginatedTransactionsResponseDto } from '../dto/paginated-transactions-response.dto';
 
 /**
@@ -34,8 +34,7 @@ export class TransactionPaginationService {
   constructor(
     @InjectRepository(Transaction)
     private readonly transactionRepository: Repository<Transaction>,
-    @InjectRepository(Event)
-    private readonly eventRepository: Repository<Event>,
+    private readonly eventAccessService: EventAccessService,
   ) {}
 
   /**
@@ -56,13 +55,7 @@ export class TransactionPaginationService {
       );
 
       // Verify event exists
-      const event = await this.eventRepository.findOne({
-        where: { id: eventId },
-      });
-
-      if (!event) {
-        throw new NotFoundException(`Event with ID ${eventId} not found`);
-      }
+      await this.eventAccessService.findEventOrThrow(eventId);
 
       const query = this.getPaginatedQuery();
       const rawResults: RankedTransactionRow[] = await this.transactionRepository.query(query, [

--- a/apps/backend/src/modules/transactions/transactions.module.ts
+++ b/apps/backend/src/modules/transactions/transactions.module.ts
@@ -5,10 +5,12 @@ import { ParticipantValidationService } from './services/participant-validation.
 import { TransactionPaginationService } from './services/transaction-pagination.service';
 import { TransactionsController, EventTransactionsController } from './transactions.controller';
 import { Transaction } from './entities/transaction.entity';
-import { Event } from '../events/entities/event.entity';
+import { EventAccessModule } from '../event-access/event-access.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Transaction, Event])],
+  // The Event entity is deliberately absent: event access goes through EventAccessModule instead of a
+  // second repository over the events table.
+  imports: [TypeOrmModule.forFeature([Transaction]), EventAccessModule],
   controllers: [EventTransactionsController, TransactionsController],
   // RequestContextService is not declared here on purpose: it lives in the global RequestContextModule
   // so the middleware and this module's services share the same AsyncLocalStorage instance.

--- a/apps/backend/src/modules/transactions/transactions.service.spec.ts
+++ b/apps/backend/src/modules/transactions/transactions.service.spec.ts
@@ -7,6 +7,7 @@ import { Event } from '../events/entities/event.entity';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { ParticipantValidationService } from './services/participant-validation.service';
 import { TransactionPaginationService } from './services/transaction-pagination.service';
+import { EventAccessService } from '../event-access/event-access.service';
 import type { AuthenticatedUser } from '../../common/types/authenticated-user.type';
 import { RequestContextService } from '../../common/request-context/request-context.service';
 
@@ -85,6 +86,9 @@ describe('TransactionsService', () => {
           provide: getRepositoryToken(Transaction),
           useValue: mockTransactionRepository,
         },
+        // The real EventAccessService is wired over a mocked event repository so these tests keep
+        // exercising the access rule itself, not just the delegation to it.
+        EventAccessService,
         {
           provide: getRepositoryToken(Event),
           useValue: mockEventRepository,

--- a/apps/backend/src/modules/transactions/transactions.service.ts
+++ b/apps/backend/src/modules/transactions/transactions.service.ts
@@ -10,13 +10,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { AuthenticatedUser } from '../../common/types/authenticated-user.type';
 import { Transaction } from './entities/transaction.entity';
-import { Event } from '../events/entities/event.entity';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { PaginatedTransactionsResponseDto } from './dto/paginated-transactions-response.dto';
 import { ParticipantValidationService } from './services/participant-validation.service';
 import { TransactionPaginationService } from './services/transaction-pagination.service';
-import { ADMIN_ROLE } from '../users/user-role.constants';
+import { EventAccessService } from '../event-access/event-access.service';
 import { RequestContextService } from '../../common/request-context/request-context.service';
 
 @Injectable()
@@ -26,42 +25,11 @@ export class TransactionsService {
   constructor(
     @InjectRepository(Transaction)
     private readonly transactionRepository: Repository<Transaction>,
-    @InjectRepository(Event)
-    private readonly eventRepository: Repository<Event>,
+    private readonly eventAccessService: EventAccessService,
     private readonly participantValidationService: ParticipantValidationService,
     private readonly transactionPaginationService: TransactionPaginationService,
     private readonly requestContext: RequestContextService,
   ) {}
-
-  private isAdmin(actor: AuthenticatedUser): boolean {
-    return actor.role === ADMIN_ROLE;
-  }
-
-  private isUserParticipant(event: Event, userId: string): boolean {
-    return (event.participants ?? []).some((participant) => participant.type === 'user' && participant.id === userId);
-  }
-
-  private ensureCanAccessEvent(event: Event, actor: AuthenticatedUser): void {
-    if (this.isAdmin(actor)) {
-      return;
-    }
-
-    if (!this.isUserParticipant(event, actor.id)) {
-      throw new ForbiddenException(`Access to event ${event.id} is not allowed`);
-    }
-  }
-
-  private async findEventOrThrow(eventId: string): Promise<Event> {
-    const event = await this.eventRepository.findOne({
-      where: { id: eventId },
-    });
-
-    if (!event) {
-      throw new NotFoundException(`Event with ID ${eventId} not found`);
-    }
-
-    return event;
-  }
 
   private async findTransactionOrThrow(id: string): Promise<Transaction> {
     const transaction = await this.transactionRepository.findOne({ where: { id } });
@@ -73,16 +41,20 @@ export class TransactionsService {
     return transaction;
   }
 
+  /**
+   * Authorize a transaction through its parent event. A missing parent event is reported as a missing
+   * transaction on purpose, so the response never reveals whether the event exists.
+   */
   private async ensureCanAccessTransaction(transaction: Transaction, actor: AuthenticatedUser): Promise<void> {
-    if (this.isAdmin(actor)) {
+    if (this.eventAccessService.isAdmin(actor)) {
       return;
     }
 
-    const event = await this.eventRepository.findOne({ where: { id: transaction.eventId } });
+    const event = await this.eventAccessService.findEvent(transaction.eventId);
     if (!event) {
       throw new NotFoundException(`Transaction with ID ${transaction.id} not found`);
     }
-    if (!this.isUserParticipant(event, actor.id)) {
+    if (!this.eventAccessService.canAccessEvent(event, actor)) {
       throw new ForbiddenException(`Access to transaction ${transaction.id} is not allowed`);
     }
   }
@@ -94,9 +66,8 @@ export class TransactionsService {
     try {
       this.logger.log(`Fetching transactions for event: ${eventId}`);
 
-      // Verify event exists
-      const event = await this.findEventOrThrow(eventId);
-      this.ensureCanAccessEvent(event, actor);
+      // Verify the event exists and the actor can access it
+      await this.eventAccessService.loadAccessibleEvent(eventId, actor);
 
       const transactions = await this.transactionRepository.find({
         where: { eventId },
@@ -134,8 +105,7 @@ export class TransactionsService {
     offset: number,
     actor: AuthenticatedUser,
   ): Promise<PaginatedTransactionsResponseDto> {
-    const event = await this.findEventOrThrow(eventId);
-    this.ensureCanAccessEvent(event, actor);
+    await this.eventAccessService.loadAccessibleEvent(eventId, actor);
     return this.transactionPaginationService.findByEventPaginated(eventId, numberOfDates, offset);
   }
 
@@ -174,9 +144,8 @@ export class TransactionsService {
     try {
       this.logger.log(`Creating new transaction for event ${eventId}: ${createTransactionDto.title}`);
 
-      // Verify event exists
-      const event = await this.findEventOrThrow(eventId);
-      this.ensureCanAccessEvent(event, actor);
+      // Verify the event exists and the actor can access it
+      const event = await this.eventAccessService.loadAccessibleEvent(eventId, actor);
 
       // Validate participantId
       this.participantValidationService.validateParticipantId(
@@ -233,13 +202,7 @@ export class TransactionsService {
 
       // If participantId or paymentType is being updated, re-validate the combination
       if (updateTransactionDto.participantId || updateTransactionDto.paymentType) {
-        const event = await this.eventRepository.findOne({
-          where: { id: transaction.eventId },
-        });
-
-        if (!event) {
-          throw new NotFoundException(`Event with ID ${transaction.eventId} not found`);
-        }
+        const event = await this.eventAccessService.findEventOrThrow(transaction.eventId);
 
         const participantId = updateTransactionDto.participantId ?? transaction.participantId;
         const paymentType = updateTransactionDto.paymentType ?? transaction.paymentType;

--- a/apps/backend/test/transactions.e2e-spec.ts
+++ b/apps/backend/test/transactions.e2e-spec.ts
@@ -480,7 +480,23 @@ describe('Transactions API (e2e)', () => {
       .expect(403);
 
     await request(httpServer)
+      .get(`/api/events/${event.id}/transactions/paginated`)
+      .set('Authorization', buildAuthHeader(jwtService, outsider))
+      .expect(403);
+
+    await request(httpServer)
       .get(`/api/transactions/${transaction.id}`)
+      .set('Authorization', buildAuthHeader(jwtService, outsider))
+      .expect(403);
+
+    await request(httpServer)
+      .patch(`/api/transactions/${transaction.id}`)
+      .set('Authorization', buildAuthHeader(jwtService, outsider))
+      .send({ title: 'Outsider Rename' })
+      .expect(403);
+
+    await request(httpServer)
+      .delete(`/api/transactions/${transaction.id}`)
       .set('Authorization', buildAuthHeader(jwtService, outsider))
       .expect(403);
 


### PR DESCRIPTION
Closes #99

## Qué problema resuelve
La lógica de autorización `isAdmin` / `isUserParticipant` / `ensureCanAccessEvent` estaba duplicada literalmente en `EventsService` y `TransactionsService`, y `TransactionsModule` registraba la entidad `Event` directamente (`forFeature([Transaction, Event])`), acoplando ambos módulos a nivel de BD. Si cambiaba la regla de acceso había que tocar dos sitios y era fácil olvidar uno.

## Cambios
- Nuevo módulo `src/modules/event-access/` con `EventAccessService`, única implementación de la regla de autorización y de `findEventOrThrow`.
- `EventsModule` y `TransactionsModule` importan `EventAccessService` (no puede vivir dentro de `EventsModule` porque este ya importa `TransactionsModule`).
- `TransactionsModule` deja de registrar la entidad `Event` en `forFeature`.
- Se deduplican las cuatro copias de `findEventOrThrow` (`EventQueryService`, `TransactionsService`, `TransactionPaginationService`).
- 3 casos e2e nuevos (403 en `paginated`, `PATCH` y `DELETE` de transacciones) añadidos como red de seguridad antes del refactor, para verificar que el comportamiento no cambia.

## Criterios de aceptación
- [x] Una única implementación de la regla de acceso — verificado con grep, solo aparece en `src/modules/event-access/`.
- [x] `TransactionsModule` ya no tiene `Event` en `forFeature`.
- [x] Comportamiento idéntico verificado por los specs de control de acceso existentes más los 3 casos e2e nuevos.
- [x] Tests en verde.

## Verificación
- `pnpm --filter @friends/backend check:backend` — lint + 227 unit + 35 integration + 52 e2e, todo verde.
- `pnpm -r build` — type-check OK.

## Nota para el revisor
- `TransactionPaginationService` también inyectaba `Repository<Event>` (no estaba en el enunciado de la issue); ahora usa `EventAccessService.findEventOrThrow`.
- Los unit specs inyectan el `EventAccessService` real sobre un repositorio mockeado, para que los tests de 403 sigan ejercitando la regla y no solo la delegación.

## Fuera de alcance
Posible issue de seguimiento: una petición de KPIs sigue cargando el mismo evento tres veces (`EventsService.getKPIs` → `EventKPIsService.getKPIs` → `TransactionsService.findByEvent`).
