### PR TITLE
docs(claude): revise CLAUDE.md with /init findings and fix stale claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ Friends is an expense-sharing platform for group events. pnpm monorepo with:
 - `@friends/backend` → `apps/backend/` — NestJS + TypeORM + PostgreSQL
 - `@friends/shared-types` → `packages/shared-types/` — Shared TypeScript types
 
+Versioning is SemVer on the **root `package.json` only**; every workspace manifest is private and stays at
+`0.0.0`. Infrastructure and production operations are documented in [DEPLOYMENT.md](DEPLOYMENT.md) — it is
+canonical, do not restate it here.
+
 ## Commands
 
 ```bash
@@ -31,18 +35,43 @@ pnpm format
 pnpm --filter @friends/frontend test        # watch
 pnpm --filter @friends/frontend test:run    # CI
 pnpm --filter @friends/frontend test:coverage
+pnpm --filter @friends/frontend test:run -- src/api/client.test.ts   # single file
+pnpm --filter @friends/frontend test:run -- -t "refreshes the token"  # single test
 
-# Backend tests (Jest)
-pnpm --filter @friends/backend test         # watch
-pnpm --filter @friends/backend test:run     # CI
-pnpm --filter @friends/backend check:backend  # lint + all tests
+# Backend tests (Jest) — three separate suites, three configs
+pnpm --filter @friends/backend test         # unit, watch
+pnpm --filter @friends/backend test:run     # unit + coverage (this is what root `pnpm test` runs)
+pnpm --filter @friends/backend test:int     # integration — needs Postgres + .env.test
+pnpm --filter @friends/backend test:e2e     # e2e — needs Postgres + .env.test
+pnpm --filter @friends/backend test:all     # the three of them
+pnpm --filter @friends/backend check:backend  # lint + test:all
+pnpm --filter @friends/backend test:e2e -- test/events.e2e-spec.ts   # single file
 
 # Backend DB
 cd apps/backend && docker-compose up -d     # start PostgreSQL
 pnpm --filter @friends/backend migration:run
 ```
 
-Backend has three Jest configs: `test/jest.unit.json`, `test/jest.integration.json`, `test/jest.e2e.json`.
+**Type-checking only happens in `build`.** `check:backend` runs lint + tests, neither of which type-checks;
+`pnpm build` is the only thing that does (frontend `tsc -b`, backend `nest build`). A change can be green on
+`check:backend` and still fail to compile.
+
+**`@friends/shared-types` is consumed from `dist/`.** Both apps import the built output, so a change there
+needs `pnpm --filter @friends/shared-types build` before the consumers see it (the backend `prebuild` does
+this; a watching dev server does not).
+
+### Environment
+
+Backend loads `.env.${NODE_ENV}` (`.env.development`, `.env.test`, `.env.production`) and validates it with
+the Joi schema in `src/config/env.validation.ts` — that schema, not the `.env.example` files, is the source
+of truth for which vars exist, which are required and what the defaults are. Boot fails loudly on a bad env.
+
+The backend integration and e2e suites need a running Postgres *and* an `apps/backend/.env.test` copied from
+`.env.test.example` (gitignored). That file sets `TYPEORM_SYNC=true`, so those suites build the schema
+themselves and do not run migrations.
+
+Frontend env vars are `VITE_`-prefixed and validated at module load in `src/config/env.ts`
+(`VITE_API_URL` and `VITE_APP_NAME` are required; a missing or malformed one throws at startup).
 
 ## Frontend Architecture
 
@@ -56,6 +85,9 @@ src/api/                  client.ts, types.ts + per-entity modules (events.api.t
 src/hooks/api/            TanStack Query hooks + centralized keys.ts
 src/shared/store/         Zustand stores (theme, modals, toast, delete state)
 src/pages/                Route-level components
+src/providers/            QueryProvider (wraps the app in App.tsx)
+src/lib/queryClient.ts    The single QueryClient instance and its defaults
+src/shared/components/ui/ Radix primitives wrapped for this design system (dialog, dropdown-menu)
 src/i18n/locales/         es/ (default), en/, ca/
 src/config/env.ts         Validated env vars via VITE_ prefix
 ```
@@ -68,9 +100,17 @@ Features: `events`, `transactions`, `kpi`, `auth`, `admin-users`, `profile`
 2. **UI/modal state:** Zustand stores (`useEventFormModalStore`, `useTransactionModalStore`, etc.)
 3. **Global state:** `useThemeStore` (dark mode only)
 
-### API client
+### API client and the token model
 
 `src/api/client.ts` — custom fetch wrapper that auto-unwraps `{ data: T }` responses, handles JWT refresh, and throws `ApiError` with status info.
+
+The token split is deliberate and easy to break:
+
+- **Access token lives in a module-level variable, never in storage** — a persistent XSS cannot read it. It is
+  lost on reload and re-obtained from the refresh token. Do not "fix" this by persisting it.
+- **Refresh token lives in `localStorage`** under `REFRESH_TOKEN_KEY`, and is rotated on every refresh.
+- On a `401` the client refreshes once and replays the request (`_retried` guard); a failed refresh dispatches
+  a global `auth:logout` event, which `AuthContext` listens for. Concurrent 401s share one `refreshPromise`.
 
 ### Key conventions
 
@@ -83,6 +123,10 @@ Features: `events`, `transactions`, `kpi`, `auth`, `admin-users`, `profile`
 - Semantic colors: blue=contributions, rose=expenses, emerald=compensations, amber=pot
 
 ### Routes
+
+Vite `base` is `/friends-web/` (GitHub Pages subpath) and routing is a `HashRouter`, so production URLs look
+like `/friends-web/#/event/:id`. That is why `FRONTEND_URL` on the backend carries a trailing `#` — the OAuth
+redirect has to land inside the hash router. Every route below is lazy-loaded in [App.tsx](apps/frontend/src/App.tsx).
 
 - `/login`, `/auth/callback` — OAuth flow
 - `/` — Home (event list, protected)
@@ -111,21 +155,61 @@ separate tree. Global setup: `src/test/setup.ts`.
 ### Module structure
 
 ```
-src/modules/{module}/   controller.ts, service.ts, module.ts, entities/, dto/
-src/common/             HttpExceptionFilter, TransformInterceptor, @CurrentUser(), @ApiStandardResponse()
-src/config/             database.config.ts, app.config.ts
-src/migrations/         TypeORM migration files
+src/modules/{module}/       controller.ts, service.ts, module.ts, entities/, dto/, services/
+src/common/bootstrap/       configure-app.ts — shared by main.ts and the test harness
+src/common/                 HttpExceptionFilter, TransformInterceptor, @CurrentUser(), @ApiStandardResponse()
+src/common/request-context/ RequestContextService (global module, registered once)
+src/common/middleware/      CorrelationMiddleware — x-correlation-id, applied to '*'
+src/common/health.controller.ts
+src/config/                 database.config.ts, app.config.ts, env.validation.ts, auth.constants.ts
+src/migrations/             TypeORM migration files
 ```
 
-Modules: `auth`, `events`, `transactions`, `users`, `admin`
+Modules: `auth`, `events`, `transactions`, `users`, `admin`, `event-access`
+
+A module that grows past one service splits into `{module}/services/` (see `events/services/`,
+`transactions/services/`) rather than fattening the root service.
 
 ### Global behavior
 
+Everything shared between production and tests is applied by `configureApp()` in
+[configure-app.ts](apps/backend/src/common/bootstrap/configure-app.ts) — **e2e tests build their app through
+it**, so a global added only in `main.ts` will not be exercised by the suites. `main.ts` keeps only the
+environment-dependent wiring (CORS, Swagger, `listen`).
+
 - API prefix: `/api` — Swagger at `/api/docs`
+- `helmet()` first, so security headers cover everything downstream
 - All responses wrapped as `{ data: T }` via `TransformInterceptor`
-- Global `ValidationPipe` with `whitelist: true`, `transform: true`
+- Global `ValidationPipe` with `whitelist`, **`forbidNonWhitelisted`** (an unknown body property is a 400, not
+  a silent strip), `transform` and `enableImplicitConversion`
+- `HttpExceptionFilter` owns the error contract
+- Global `ThrottlerGuard` (100 req/min) via `APP_GUARD`, and `nestjs-pino` for logging — request ids come from
+  `x-correlation-id` when present, `/api/health` is excluded from access logs
 - `@CurrentUser()` decorator extracts authenticated user from JWT
 - `RolesGuard` + `@Roles()` for role-based access
+
+### Authorization
+
+`EventAccessService` (`modules/event-access/`) is the **single owner** of the event access rule: an actor may
+access an event if it is an admin, or is listed as a participant of `type: 'user'`. Guest participants that
+happen to share an id grant nothing. Any module needing to authorize an event depends on this service —
+do not re-derive the rule against your own repository.
+
+### API surface
+
+Transactions are exposed twice, and the split matters when adding endpoints: collection operations are nested
+under the event (`/api/events/:eventId/transactions`, plus `.../paginated`) while operations on a single
+transaction are flat (`/api/transactions/:id`). Admin user management is `/api/admin/users` behind
+`@Roles('admin')`.
+
+### Auth flow
+
+OAuth callback → the backend mints a **one-time exchange code** (`AuthExchangeCode` entity, TTL from
+`AUTH_EXCHANGE_CODE_TTL_SECONDS`) and redirects to `FRONTEND_URL` with it → the frontend `POST /api/auth/exchange`
+trades it for an access token + refresh token. Tokens never travel in the redirect URL. Refresh tokens are
+persisted (`RefreshToken` entity), rotated on use and capped by `REFRESH_TOKEN_MAX_ROTATIONS`.
+Google and Microsoft strategies share `strategies/base/oauth-validation.base.ts`; avatars go to Cloudinary
+via `services/avatar.service.ts`.
 
 ### Patterns
 
@@ -133,8 +217,27 @@ Modules: `auth`, `events`, `transactions`, `users`, `admin`
 - Services own business logic; throw NestJS exceptions (`NotFoundException`, etc.)
 - DTOs use `class-validator` decorators
 - Swagger: `@ApiOperation` + `@ApiStandardResponse(status, description, type, isArray?)`
+- **Money is `decimal.js`, never native numbers.** Amounts are `decimal(10,2)` and Postgres returns them as
+  strings, so aggregate with `new Decimal(String(amount))` (rounding is `ROUND_HALF_EVEN`, set globally) and
+  `.toNumber()` only when serializing the response. Summing with `+` reintroduces float drift into balances.
 - User entity uses soft deletes (`@DeleteDateColumn`)
 - Cascade delete: transactions deleted when parent event is deleted
+
+### Testing
+
+Three suites, three configs, three naming conventions — the config decides what runs, so a misnamed file is
+silently never executed:
+
+| Suite | Config | Location and name | Needs Postgres |
+|---|---|---|---|
+| unit | `test/jest.unit.json` | co-located, `src/**/*.spec.ts` | no |
+| integration | `test/jest.integration.json` | `test/**/*.int-spec.ts` | yes |
+| e2e | `test/jest.e2e.json` | `test/**/*.e2e-spec.ts` | yes |
+
+Shared helpers for the DB-backed suites live in `test/utils/` (`test-app-config.ts`, `test-factories.ts`,
+`test-http-helpers.ts`) — reuse them instead of hand-rolling app bootstrap or fixtures. The unit config
+enforces coverage thresholds (global, plus a stricter per-file gate on
+`events/services/event-participants.service.ts`), so uncovered new code fails the run.
 
 ### Database
 
@@ -145,9 +248,13 @@ production boot), `migration:revert`.
 ## Domain Model
 
 **Participant** (JSONB union in Event):
-- `UserParticipant`: `{ type: 'user', id: UUID, name?, email?, avatar? }`
-- `GuestParticipant`: `{ type: 'guest', id: string, name: string }`
-- `PotParticipant`: `{ type: 'pot', id: '0' }` — shared expenses (amber UI)
+- `UserParticipant`: `{ type: 'user', id: UUID, name?, email?, avatar?, contributionTarget? }`
+- `GuestParticipant`: `{ type: 'guest', id: string, name: string, contributionTarget? }`
+- `PotParticipant`: `{ type: 'pot', id: '0' }` — shared expenses (amber UI), no target
+
+`contributionTarget` is what each participant is expected to put in; the *pending* KPI is
+`netContribution - contributionTarget` per participant. Dropping it when building a participant silently
+zeroes that KPI.
 
 **Event:** id, title, description?, icon?, status (`active` | `archived`), participants (JSONB), timestamps
 
@@ -172,7 +279,7 @@ improvise a GitHub flow, and do not commit, push, open or merge anything without
 
 ## Conventions
 
-**Git commits:** `type(scope): description` — types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore` — scopes: `frontend`, `backend`, `shared-types`, `ci`
+**Git commits:** `type(scope): description` — types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore` — scopes: `frontend`, `backend`, `shared-types`, `ci`, `docs`, `a11y`
 
 **Code language:** All comments, JSDoc, and type descriptions in English. i18n translation files stay in their own languages.
 


### PR DESCRIPTION
## Qué problema resuelve

Es la revisión de `CLAUDE.md` salida de un `/init`: documenta comportamiento del repo que hasta ahora costaba varios ficheros descubrir, y corrige cuatro afirmaciones que estaban incompletas o eran directamente falsas. Todo el contenido sale de leer el código, no de suposiciones.

## Cambios

**Documenta lo que faltaba:**
- Las tres suites del backend (unit / integration / e2e), sus configs, convenciones de nombre y prerequisitos (Postgres + `.env.test`)
- Que solo `pnpm build` hace type-check (`check:backend` no) y que `@friends/shared-types` se consume desde `dist/`
- Sección Environment: `.env.${NODE_ENV}` y el schema de Joi como fuente de verdad
- El modelo de tokens del frontend: access token en memoria a propósito, refresh token rotativo en `localStorage`, retry único ante 401
- `configureApp()` como el bootstrap compartido con los tests e2e
- `EventAccessService` como dueño único de la regla de acceso a eventos
- El flujo de auth con exchange code de un solo uso
- Superficie de la API de transactions (anidada vs. plana) y la estructura real de módulos y `src/common/`

**Corrige afirmaciones incompletas o falsas:**
- El `ValidationPipe` global también lleva `forbidNonWhitelisted`: una propiedad desconocida en el body es un 400, no un descarte silencioso
- Faltaba el módulo `event-access` en la lista de módulos
- `UserParticipant`/`GuestParticipant` llevan `contributionTarget`, base del KPI "pending"
- El dinero se calcula con `decimal.js`, nunca con números nativos

## Verificación

- `pnpm lint` — verde (`check:skills` + eslint frontend y backend)
- `pnpm test` — verde (frontend: 33 archivos de test; backend: 24 suites, 227 tests)
- `pnpm build` — verde (frontend, backend y `shared-types`)

Cambio de solo documentación: no hay código de aplicación afectado, así que no aplica prueba manual adicional.