### PR TITLE
fix(backend,frontend): hacer honesto el tipo de Transaction.amount y enrutar los fetches de auth por el cliente API (#100)

### DIFF
--- a/apps/backend/src/common/transformers/column-numeric.transformer.spec.ts
+++ b/apps/backend/src/common/transformers/column-numeric.transformer.spec.ts
@@ -1,0 +1,38 @@
+import { ColumnNumericTransformer, columnNumericTransformer } from './column-numeric.transformer';
+
+describe('ColumnNumericTransformer', () => {
+  const transformer = new ColumnNumericTransformer();
+
+  describe('to (entity -> database)', () => {
+    it('passes numbers through untouched', () => {
+      expect(transformer.to(21)).toBe(21);
+      expect(transformer.to(33.5)).toBe(33.5);
+      expect(transformer.to(0)).toBe(0);
+    });
+
+    it('passes null through', () => {
+      expect(transformer.to(null)).toBeNull();
+    });
+  });
+
+  describe('from (database -> entity)', () => {
+    it('parses the string the driver returns into a number', () => {
+      expect(transformer.from('21.00')).toBe(21);
+      expect(transformer.from('33.50')).toBe(33.5);
+      expect(transformer.from('0.01')).toBe(0.01);
+    });
+
+    it('round-trips the widest decimal(10,2) value', () => {
+      expect(transformer.from('99999999.99')).toBe(99999999.99);
+    });
+
+    it('returns null for null and undefined', () => {
+      expect(transformer.from(null)).toBeNull();
+      expect(transformer.from(undefined as unknown as string)).toBeNull();
+    });
+  });
+
+  it('exposes a shared instance', () => {
+    expect(columnNumericTransformer).toBeInstanceOf(ColumnNumericTransformer);
+  });
+});

--- a/apps/backend/src/common/transformers/column-numeric.transformer.ts
+++ b/apps/backend/src/common/transformers/column-numeric.transformer.ts
@@ -1,0 +1,33 @@
+import { ValueTransformer } from 'typeorm';
+
+/**
+ * Keeps `decimal` columns honest with their declared TypeScript type.
+ *
+ * The Postgres driver returns `numeric`/`decimal` values as strings to avoid the
+ * precision loss of a JS double, so an entity field declared as `number` holds a
+ * string at runtime unless a transformer converts it back. Every read path then
+ * has to defend itself, and any consumer that trusts the declared type does
+ * arithmetic on a string without TypeScript complaining.
+ *
+ * Safe for `decimal(10,2)` money columns: the widest value (99999999.99) has ten
+ * significant digits, well inside the ~15 a double represents exactly enough to
+ * round-trip at two decimals. This does NOT make float arithmetic safe — money is
+ * still aggregated with decimal.js.
+ */
+export class ColumnNumericTransformer implements ValueTransformer {
+  /** Entity -> database. The driver serializes the number itself. */
+  to(value: number | null): number | null {
+    return value;
+  }
+
+  /** Database -> entity. */
+  from(value: string | null): number | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    return parseFloat(value);
+  }
+}
+
+export const columnNumericTransformer = new ColumnNumericTransformer();

--- a/apps/backend/src/modules/transactions/entities/transaction.entity.ts
+++ b/apps/backend/src/modules/transactions/entities/transaction.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import { Event } from '../../events/entities/event.entity';
 import { PaymentType } from '@friends/shared-types';
+import { columnNumericTransformer } from '../../../common/transformers/column-numeric.transformer';
 
 export type { PaymentType } from '@friends/shared-types';
 
@@ -29,7 +30,9 @@ export class Transaction {
   })
   paymentType: PaymentType;
 
-  @Column('decimal', { precision: 10, scale: 2 })
+  // The transformer is what makes `number` true at runtime: without it the
+  // driver hands back a string for decimal columns.
+  @Column('decimal', { precision: 10, scale: 2, transformer: columnNumericTransformer })
   amount: number;
 
   @Column({ length: 50, name: 'participant_id' })

--- a/apps/backend/src/modules/transactions/services/transaction-pagination.service.ts
+++ b/apps/backend/src/modules/transactions/services/transaction-pagination.service.ts
@@ -144,6 +144,8 @@ export class TransactionPaginationService {
       transaction.eventId = row.event_id;
       transaction.participantId = row.participant_id;
       transaction.paymentType = row.payment_type as Transaction['paymentType'];
+      // Raw SQL bypasses the entity's column transformer, so the decimal still
+      // arrives as a string here and has to be parsed by hand.
       transaction.amount = parseFloat(row.amount);
       transaction.title = row.title;
       transaction.date = row.date;

--- a/apps/backend/test/transactions-amount.int-spec.ts
+++ b/apps/backend/test/transactions-amount.int-spec.ts
@@ -1,0 +1,115 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AppModule } from '../src/app.module';
+import { Event, EventStatus } from '../src/modules/events/entities/event.entity';
+import { Transaction } from '../src/modules/transactions/entities/transaction.entity';
+import { PaymentType } from '@friends/shared-types';
+import { createEvent, createTransaction } from './utils/test-factories';
+
+/**
+ * `amount` is a decimal column, which the Postgres driver returns as a string. These tests
+ * pin the column transformer that keeps the runtime value matching the declared `number`.
+ */
+describe('Transaction.amount runtime type (integration)', () => {
+  let app: INestApplication;
+  let eventRepository: Repository<Event>;
+  let transactionRepository: Repository<Transaction>;
+  let event: Event;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    eventRepository = app.get<Repository<Event>>(getRepositoryToken(Event));
+    transactionRepository = app.get<Repository<Transaction>>(getRepositoryToken(Transaction));
+  });
+
+  beforeEach(async () => {
+    await transactionRepository.createQueryBuilder().delete().from(Transaction).execute();
+    await eventRepository.createQueryBuilder().delete().from(Event).execute();
+
+    event = await createEvent(eventRepository, {
+      title: 'Amount Event',
+      status: EventStatus.ACTIVE,
+      participants: [{ type: 'guest', id: 'g1', name: 'Guest 1' }],
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns a number when reading a transaction back', async () => {
+    const saved = await createTransaction(transactionRepository, {
+      title: 'Dinner',
+      paymentType: PaymentType.EXPENSE,
+      amount: 33.5,
+      participantId: 'g1',
+      eventId: event.id,
+    });
+
+    const found = await transactionRepository.findOne({ where: { id: saved.id } });
+
+    expect(found).not.toBeNull();
+    expect(typeof found!.amount).toBe('number');
+    expect(found!.amount).toBe(33.5);
+  });
+
+  it('returns numbers when reading a collection', async () => {
+    await createTransaction(transactionRepository, {
+      title: 'Contribution',
+      paymentType: PaymentType.CONTRIBUTION,
+      amount: 21,
+      participantId: 'g1',
+      eventId: event.id,
+    });
+
+    const [found] = await transactionRepository.find({ where: { eventId: event.id } });
+
+    expect(typeof found.amount).toBe('number');
+    expect(found.amount).toBe(21);
+  });
+
+  it('round-trips values that need both decimals', async () => {
+    const saved = await createTransaction(transactionRepository, {
+      title: 'Odd cents',
+      paymentType: PaymentType.EXPENSE,
+      amount: 10.01,
+      participantId: 'g1',
+      eventId: event.id,
+    });
+
+    const found = await transactionRepository.findOneOrFail({ where: { id: saved.id } });
+
+    expect(found.amount).toBe(10.01);
+  });
+
+  it('keeps the value arithmetic-safe without coercion', async () => {
+    await createTransaction(transactionRepository, {
+      title: 'First',
+      paymentType: PaymentType.EXPENSE,
+      amount: 10.5,
+      participantId: 'g1',
+      eventId: event.id,
+    });
+    await createTransaction(transactionRepository, {
+      title: 'Second',
+      paymentType: PaymentType.EXPENSE,
+      amount: 4.5,
+      participantId: 'g1',
+      eventId: event.id,
+    });
+
+    const found = await transactionRepository.find({ where: { eventId: event.id } });
+    const total = found.reduce((sum, transaction) => sum + transaction.amount, 0);
+
+    // A string amount would concatenate here instead of adding up.
+    expect(total).toBe(15);
+  });
+});

--- a/apps/backend/test/transactions.e2e-spec.ts
+++ b/apps/backend/test/transactions.e2e-spec.ts
@@ -169,6 +169,9 @@ describe('Transactions API (e2e)', () => {
       participantId: 'g1',
       eventId: event.id,
     });
+    // The three routes below read the amount through different code paths (save
+    // result, entity read, raw SQL); all must serialize it as a JSON number.
+    expect(createData.amount).toBe(33.5);
 
     const listResponse = await request(httpServer)
       .get(`/api/events/${event.id}/transactions`)
@@ -177,8 +180,9 @@ describe('Transactions API (e2e)', () => {
 
     const listData = getDataFromBody(listResponse.body);
     expect(Array.isArray(listData)).toBe(true);
-    const list = listData as unknown[];
+    const list = listData as Array<Record<string, unknown>>;
     expect(list).toHaveLength(1);
+    expect(list[0].amount).toBe(33.5);
 
     const paginatedResponse = await request(httpServer)
       .get(`/api/events/${event.id}/transactions/paginated?numberOfDates=3&offset=0`)
@@ -191,7 +195,9 @@ describe('Transactions API (e2e)', () => {
       totalDates: 1,
       loadedDates: 1,
     });
-    expect(Array.isArray((paginatedData as { transactions?: unknown }).transactions)).toBe(true);
+    const paginatedTransactions = (paginatedData as { transactions?: unknown }).transactions;
+    expect(Array.isArray(paginatedTransactions)).toBe(true);
+    expect((paginatedTransactions as Array<Record<string, unknown>>)[0].amount).toBe(33.5);
   });
 
   it('GET /api/events/:eventId/transactions/paginated returns 400 for invalid query params', async () => {
@@ -260,6 +266,7 @@ describe('Transactions API (e2e)', () => {
       eventId: event.id,
       participantId: 'g1',
     });
+    expect(data.amount).toBe(18);
   });
 
   it('GET /api/transactions/:id returns 404 for non-existing transaction', async () => {
@@ -322,7 +329,7 @@ describe('Transactions API (e2e)', () => {
       id: created.id,
       title: 'Museum Updated',
     });
-    expect(Number(data.amount)).toBe(21);
+    expect(data.amount).toBe(21);
   });
 
   it('PATCH /api/transactions/:id returns 404 for non-existing transaction', async () => {

--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -35,6 +35,22 @@ export default [
     },
   },
   {
+    // Every HTTP call goes through apiRequest, which owns the JWT refresh, the
+    // { data } unwrapping and the ApiError contract. src/api/client.ts is the
+    // one place allowed to touch fetch directly.
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/api/client.ts', 'src/**/*.test.{ts,tsx}', 'src/test/**'],
+    rules: {
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'fetch',
+          message: 'Use apiRequest from @/api/client instead of calling fetch directly.',
+        },
+      ],
+    },
+  },
+  {
     files: ['**/*.js'],
     languageOptions: {
       globals: {

--- a/apps/frontend/src/api/auth.api.test.ts
+++ b/apps/frontend/src/api/auth.api.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { apiRequestMock } = vi.hoisted(() => ({ apiRequestMock: vi.fn() }));
+
+vi.mock('@/config/env', () => ({
+  ENV: { API_URL: 'http://test.api' },
+}));
+
+vi.mock('./client', () => ({
+  apiRequest: apiRequestMock,
+}));
+
+const { authApi } = await import('./auth.api');
+
+describe('authApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiRequestMock.mockResolvedValue(null);
+  });
+
+  it('posts the one-time code to /auth/exchange without the 401 refresh', async () => {
+    await authApi.exchangeCode('one-time-code');
+
+    expect(apiRequestMock).toHaveBeenCalledWith('/auth/exchange', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'one-time-code' }),
+      skipAuthRefresh: true,
+    });
+  });
+
+  it('reads the profile from /auth/me with the default refresh-and-replay', async () => {
+    await authApi.getCurrentUser();
+
+    expect(apiRequestMock).toHaveBeenCalledWith('/auth/me');
+  });
+
+  it('revokes the refresh token without the 401 refresh', async () => {
+    // Opting out matters here: logout clears the refresh token first, so a 401
+    // that triggered a refresh would emit auth:logout and recurse.
+    await authApi.logout('stored-refresh');
+
+    expect(apiRequestMock).toHaveBeenCalledWith('/auth/logout', {
+      method: 'POST',
+      body: JSON.stringify({ refreshToken: 'stored-refresh' }),
+      skipAuthRefresh: true,
+    });
+  });
+
+  it('still calls the endpoint when no refresh token is stored', async () => {
+    await authApi.logout(null);
+
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      '/auth/logout',
+      expect.objectContaining({ body: JSON.stringify({ refreshToken: null }) }),
+    );
+  });
+
+  it('builds the OAuth entry point from the validated API URL', () => {
+    expect(authApi.oauthLoginUrl('google')).toBe('http://test.api/auth/google');
+    expect(authApi.oauthLoginUrl('microsoft')).toBe('http://test.api/auth/microsoft');
+  });
+});

--- a/apps/frontend/src/api/auth.api.ts
+++ b/apps/frontend/src/api/auth.api.ts
@@ -1,0 +1,53 @@
+import { ENV } from '@/config/env';
+import { apiRequest } from './client';
+import type { AuthProvider, User } from '@/features/auth/types';
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * Auth API endpoints
+ * All methods use the apiRequest wrapper for consistent error handling
+ */
+export const authApi = {
+  /**
+   * Redeem the one-time OAuth callback code for a token pair
+   * @param code - One-time exchange code from the callback URL
+   * @returns Access and refresh tokens
+   */
+  exchangeCode: (code: string) =>
+    apiRequest<AuthTokens>('/auth/exchange', {
+      method: 'POST',
+      body: JSON.stringify({ code }),
+      // No session exists yet, so a 401 here means the code is bad, not that
+      // the access token expired.
+      skipAuthRefresh: true,
+    }),
+
+  /**
+   * Get the authenticated user's profile
+   * @returns Current user
+   */
+  getCurrentUser: () => apiRequest<User>('/auth/me'),
+
+  /**
+   * Revoke the refresh token server-side
+   * @param refreshToken - Refresh token to revoke, if any is stored
+   * @returns void
+   */
+  logout: (refreshToken: string | null) =>
+    apiRequest<null>('/auth/logout', {
+      method: 'POST',
+      body: JSON.stringify({ refreshToken }),
+      skipAuthRefresh: true,
+    }),
+
+  /**
+   * Build the OAuth entry point URL for a provider
+   * @param provider - OAuth provider to authenticate with
+   * @returns Absolute URL to redirect the browser to
+   */
+  oauthLoginUrl: (provider: AuthProvider) => `${ENV.API_URL}/auth/${provider}`,
+};

--- a/apps/frontend/src/api/client.test.ts
+++ b/apps/frontend/src/api/client.test.ts
@@ -127,6 +127,36 @@ describe('apiRequest', () => {
       window.removeEventListener('auth:logout', logoutListener);
     });
 
+    it('does not refresh, retry or dispatch auth:logout when skipAuthRefresh is set', async () => {
+      setAccessToken('old-token');
+      localStorage.setItem(REFRESH_TOKEN_KEY, 'refresh-token');
+
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(401, { message: 'Unauthorized' }));
+
+      const logoutListener = vi.fn();
+      window.addEventListener('auth:logout', logoutListener);
+
+      await expect(apiRequest('/auth/logout', { method: 'POST', skipAuthRefresh: true })).rejects.toMatchObject({
+        status: 401,
+      });
+
+      // Otherwise logging out would fail its own refresh, emit auth:logout and
+      // call itself again, forever.
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(logoutListener).not.toHaveBeenCalled();
+      expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('refresh-token');
+
+      window.removeEventListener('auth:logout', logoutListener);
+    });
+
+    it('does not leak skipAuthRefresh into the fetch options', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse(200, { data: { ok: true } }));
+
+      await apiRequest('/auth/exchange', { method: 'POST', skipAuthRefresh: true });
+
+      expect(vi.mocked(fetch).mock.calls[0][1]).not.toHaveProperty('skipAuthRefresh');
+    });
+
     it('does not retry /auth/refresh endpoint on 401', async () => {
       setAccessToken('old-token');
       localStorage.setItem(REFRESH_TOKEN_KEY, 'refresh-token');

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -5,8 +5,15 @@ let refreshPromise: Promise<string | null> | null = null;
 
 export const REFRESH_TOKEN_KEY = 'refresh_token';
 
-interface ApiRequestInit extends RequestInit {
+export interface ApiRequestInit extends RequestInit {
   _retried?: boolean;
+  /**
+   * Opt out of the 401 refresh-and-replay. Needed by the auth endpoints that are
+   * part of the refresh cycle themselves: logging out clears the refresh token
+   * first, so a 401 there would fail the refresh, emit `auth:logout` and call
+   * logout again, forever.
+   */
+  skipAuthRefresh?: boolean;
 }
 
 // The access token lives only in memory so a persistent XSS cannot read it
@@ -83,7 +90,7 @@ export class ApiError extends Error {
  */
 export async function apiRequest<T>(endpoint: string, options?: ApiRequestInit): Promise<T> {
   const requestOptions = options ?? {};
-  const { _retried: hasRetried = false, ...baseOptions } = requestOptions;
+  const { _retried: hasRetried = false, skipAuthRefresh = false, ...baseOptions } = requestOptions;
 
   let response: Response;
   const token = accessToken;
@@ -111,7 +118,7 @@ export async function apiRequest<T>(endpoint: string, options?: ApiRequestInit):
   const contentType = response.headers.get('content-type') || '';
 
   if (!response.ok) {
-    if (response.status === 401 && !hasRetried && endpoint !== '/auth/refresh') {
+    if (response.status === 401 && !hasRetried && !skipAuthRefresh && endpoint !== '/auth/refresh') {
       const newToken = await refreshAccessToken();
 
       if (newToken) {

--- a/apps/frontend/src/features/auth/AuthContext.test.tsx
+++ b/apps/frontend/src/features/auth/AuthContext.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { use } from 'react';
+import { ApiError } from '@/api/client';
 import { AuthProvider, AuthContext } from './AuthContext';
 
 const resetEventFormModal = vi.fn();
@@ -8,15 +9,33 @@ const resetTransactionModal = vi.fn();
 const resetToast = vi.fn();
 const resetDeleting = vi.fn();
 
-const { refreshAccessTokenMock, setAccessTokenMock } = vi.hoisted(() => ({
+const { refreshAccessTokenMock, setAccessTokenMock, getCurrentUserMock, logoutMock } = vi.hoisted(() => ({
   refreshAccessTokenMock: vi.fn(),
   setAccessTokenMock: vi.fn(),
+  getCurrentUserMock: vi.fn(),
+  logoutMock: vi.fn(),
 }));
 
-vi.mock('@/api/client', () => ({
-  REFRESH_TOKEN_KEY: 'refresh_token',
-  refreshAccessToken: refreshAccessTokenMock,
-  setAccessToken: setAccessTokenMock,
+vi.mock('@/config/env', () => ({
+  ENV: { API_URL: 'http://test.api' },
+}));
+
+vi.mock('@/api/client', async () => {
+  const actual = await vi.importActual<typeof import('@/api/client')>('@/api/client');
+  return {
+    ...actual,
+    REFRESH_TOKEN_KEY: 'refresh_token',
+    refreshAccessToken: refreshAccessTokenMock,
+    setAccessToken: setAccessTokenMock,
+  };
+});
+
+vi.mock('@/api/auth.api', () => ({
+  authApi: {
+    getCurrentUser: getCurrentUserMock,
+    logout: logoutMock,
+    oauthLoginUrl: (provider: string) => `http://test.api/auth/${provider}`,
+  },
 }));
 
 vi.mock('@/shared/store/useEventFormModalStore', () => ({
@@ -56,19 +75,15 @@ function renderProvider() {
   );
 }
 
-function userResponse(email = 'user@test.com') {
-  return {
-    ok: true,
-    status: 200,
-    json: () => Promise.resolve({ data: { id: '1', email, role: 'user' } }),
-  } as unknown as Response;
+function user(email = 'user@test.com') {
+  return { id: '1', email, role: 'user' as const };
 }
 
 describe('AuthProvider', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
     vi.clearAllMocks();
     refreshAccessTokenMock.mockResolvedValue('my-jwt');
+    logoutMock.mockResolvedValue(null);
   });
 
   it('sets loading to false without refreshing when no refresh token is stored', async () => {
@@ -77,12 +92,12 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('loading')).toHaveTextContent('false');
     });
     expect(refreshAccessTokenMock).not.toHaveBeenCalled();
-    expect(fetch).not.toHaveBeenCalled();
+    expect(getCurrentUserMock).not.toHaveBeenCalled();
   });
 
   it('bootstraps the session from the refresh token on mount', async () => {
     localStorage.setItem('refresh_token', 'stored-refresh');
-    vi.mocked(fetch).mockResolvedValueOnce(userResponse());
+    getCurrentUserMock.mockResolvedValueOnce(user());
 
     renderProvider();
 
@@ -103,12 +118,12 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('loading')).toHaveTextContent('false');
     });
     expect(screen.getByTestId('user')).toHaveTextContent('null');
-    expect(fetch).not.toHaveBeenCalled();
+    expect(getCurrentUserMock).not.toHaveBeenCalled();
   });
 
   it('clears user and token when /auth/me returns 401', async () => {
     localStorage.setItem('refresh_token', 'stored-refresh');
-    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 401 } as Response);
+    getCurrentUserMock.mockRejectedValueOnce(new ApiError(401, 'Unauthorized', 'Unauthorized'));
 
     renderProvider();
 
@@ -121,7 +136,7 @@ describe('AuthProvider', () => {
 
   it('sets error when /auth/me returns non-401 server error', async () => {
     localStorage.setItem('refresh_token', 'stored-refresh');
-    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+    getCurrentUserMock.mockRejectedValueOnce(new ApiError(500, 'Internal Server Error', 'boom'));
 
     renderProvider();
 
@@ -132,18 +147,18 @@ describe('AuthProvider', () => {
 
   it('sets error on network failure during fetchUser', async () => {
     localStorage.setItem('refresh_token', 'stored-refresh');
-    vi.mocked(fetch).mockRejectedValueOnce(new Error('Network down'));
+    getCurrentUserMock.mockRejectedValueOnce(new ApiError(0, 'NetworkError', 'Failed to fetch'));
 
     renderProvider();
 
     await waitFor(() => {
-      expect(screen.getByTestId('error')).toHaveTextContent('Network down');
+      expect(screen.getByTestId('error')).toHaveTextContent('network_error');
     });
   });
 
   it('clears user, in-memory token and stored refresh token on logout', async () => {
     localStorage.setItem('refresh_token', 'stored-refresh');
-    vi.mocked(fetch).mockResolvedValueOnce(userResponse());
+    getCurrentUserMock.mockResolvedValueOnce(user());
 
     renderProvider();
 
@@ -160,9 +175,48 @@ describe('AuthProvider', () => {
     expect(localStorage.getItem('refresh_token')).toBeNull();
   });
 
+  it('revokes the refresh token server-side before wiping the local session', async () => {
+    localStorage.setItem('refresh_token', 'stored-refresh');
+    getCurrentUserMock.mockResolvedValueOnce(user());
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user')).toHaveTextContent('user@test.com');
+    });
+
+    act(() => {
+      screen.getByRole('button', { name: 'logout' }).click();
+    });
+
+    expect(logoutMock).toHaveBeenCalledWith('stored-refresh');
+    // The request has to go out while the API client still holds the access
+    // token, otherwise it leaves the server-side session alive.
+    expect(logoutMock.mock.invocationCallOrder[0]).toBeLessThan(setAccessTokenMock.mock.invocationCallOrder[0]);
+  });
+
+  it('keeps the local logout immediate when the revocation request fails', async () => {
+    localStorage.setItem('refresh_token', 'stored-refresh');
+    getCurrentUserMock.mockResolvedValueOnce(user());
+    logoutMock.mockRejectedValueOnce(new ApiError(401, 'Unauthorized', 'Unauthorized'));
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user')).toHaveTextContent('user@test.com');
+    });
+
+    act(() => {
+      screen.getByRole('button', { name: 'logout' }).click();
+    });
+
+    expect(screen.getByTestId('user')).toHaveTextContent('null');
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
   it('resets all stores on logout', async () => {
     localStorage.setItem('refresh_token', 'stored-refresh');
-    vi.mocked(fetch).mockResolvedValueOnce(userResponse());
+    getCurrentUserMock.mockResolvedValueOnce(user());
 
     renderProvider();
 
@@ -182,7 +236,7 @@ describe('AuthProvider', () => {
 
   it('calls logout when auth:logout event is dispatched', async () => {
     localStorage.setItem('refresh_token', 'stored-refresh');
-    vi.mocked(fetch).mockResolvedValueOnce(userResponse());
+    getCurrentUserMock.mockResolvedValueOnce(user());
 
     renderProvider();
 

--- a/apps/frontend/src/features/auth/AuthContext.tsx
+++ b/apps/frontend/src/features/auth/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useEffect, useState, type ReactNode } from 'react';
-import { REFRESH_TOKEN_KEY, refreshAccessToken, setAccessToken } from '@/api/client';
+import { ApiError, REFRESH_TOKEN_KEY, refreshAccessToken, setAccessToken } from '@/api/client';
+import { authApi } from '@/api/auth.api';
 import type { AuthContextType, AuthProvider, User } from './types';
 import { useEventFormModalStore } from '@/shared/store/useEventFormModalStore';
 import { useTransactionModalStore } from '@/shared/store/useTransactionModalStore';
@@ -14,31 +15,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  const fetchUser = useCallback(async (jwt: string): Promise<User | null> => {
+  // The access token is read from the API client module, so callers do not pass
+  // it in: whoever obtained it has already handed it to setAccessToken.
+  const fetchUser = useCallback(async (): Promise<User | null> => {
     try {
       setError(null);
-      const res = await fetch(`${import.meta.env.VITE_API_URL || '/api'}/auth/me`, {
-        headers: { Authorization: `Bearer ${jwt}` },
-      });
+      const nextUser = await authApi.getCurrentUser();
+      setUser(nextUser);
+      return nextUser;
+    } catch (e) {
+      setUser(null);
 
-      if (res.ok) {
-        const response = (await res.json()) as { data: User };
-        setUser(response.data);
-        return response.data;
-      }
+      if (e instanceof ApiError) {
+        // A 401 here means the client already tried to refresh and failed, so
+        // the session is gone for good.
+        if (e.status === 401) {
+          setToken(null);
+          setAccessToken(null);
+          return null;
+        }
 
-      if (res.status === 401) {
-        setUser(null);
-        setToken(null);
-        setAccessToken(null);
+        setError(e.status === 0 ? new Error('network_error') : new Error(`auth_server_error_${e.status}`));
         return null;
       }
 
-      setUser(null);
-      setError(new Error(`auth_server_error_${res.status}`));
-      return null;
-    } catch (e) {
-      setUser(null);
       setError(e instanceof Error ? e : new Error('network_error'));
       return null;
     } finally {
@@ -63,12 +63,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       setToken(newAccessToken);
-      await fetchUser(newAccessToken);
+      await fetchUser();
     })();
   }, [fetchUser]);
 
   const login = (provider: AuthProvider = 'google') => {
-    window.location.href = `${import.meta.env.VITE_API_URL || '/api'}/auth/${provider}`;
+    window.location.href = authApi.oauthLoginUrl(provider);
   };
 
   const loginWithGoogle = () => {
@@ -80,8 +80,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const logout = useCallback(() => {
-    const currentToken = token;
     const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+
+    // Fire the revocation before clearing: the API client reads the access token
+    // from its own module, and an async function body runs synchronously up to
+    // its first await, so the request captures the token before the lines below
+    // wipe it.
+    void authApi.logout(refreshToken).catch(() => {
+      // Intentionally ignore logout API failures to keep local logout immediate.
+    });
 
     setUser(null);
     setToken(null);
@@ -92,18 +99,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     useTransactionModalStore.getState().reset();
     useToastStore.getState().reset();
     useDeletingStore.getState().reset();
-
-    void fetch(`${import.meta.env.VITE_API_URL || '/api'}/auth/logout`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(currentToken ? { Authorization: `Bearer ${currentToken}` } : {}),
-      },
-      body: JSON.stringify({ refreshToken }),
-    }).catch(() => {
-      // Intentionally ignore logout API failures to keep local logout immediate.
-    });
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     const handleLogout = () => {
@@ -127,7 +123,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return Promise.resolve(null);
     }
 
-    return fetchUser(token);
+    return fetchUser();
   }, [fetchUser, token]);
 
   const updateUser = useCallback((nextUser: User) => {

--- a/apps/frontend/src/features/auth/GoogleLoginButton.tsx
+++ b/apps/frontend/src/features/auth/GoogleLoginButton.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/shared/utils';
+import { authApi } from '@/api/auth.api';
 
-const GOOGLE_AUTH_URL = `${import.meta.env.VITE_API_URL || '/api'}/auth/google`;
+const GOOGLE_AUTH_URL = authApi.oauthLoginUrl('google');
 
 type GoogleLoginButtonProps = {
   fullWidth?: boolean;

--- a/apps/frontend/src/features/auth/MicrosoftLoginButton.tsx
+++ b/apps/frontend/src/features/auth/MicrosoftLoginButton.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/shared/utils';
+import { authApi } from '@/api/auth.api';
 
-const MICROSOFT_AUTH_URL = `${import.meta.env.VITE_API_URL || '/api'}/auth/microsoft`;
+const MICROSOFT_AUTH_URL = authApi.oauthLoginUrl('microsoft');
 
 type MicrosoftLoginButtonProps = {
   fullWidth?: boolean;

--- a/apps/frontend/src/pages/AuthCallback.test.tsx
+++ b/apps/frontend/src/pages/AuthCallback.test.tsx
@@ -7,12 +7,26 @@ import { AuthCallback } from './AuthCallback';
 const navigateMock = vi.fn();
 const setAuthMock = vi.fn();
 
+const { exchangeCodeMock, getCurrentUserMock, setAccessTokenMock } = vi.hoisted(() => ({
+  exchangeCodeMock: vi.fn(),
+  getCurrentUserMock: vi.fn(),
+  setAccessTokenMock: vi.fn(),
+}));
+
 vi.mock('@/config/env', () => ({
   ENV: { API_URL: 'http://test.api' },
 }));
 
 vi.mock('@/api/client', () => ({
   REFRESH_TOKEN_KEY: 'refresh_token',
+  setAccessToken: setAccessTokenMock,
+}));
+
+vi.mock('@/api/auth.api', () => ({
+  authApi: {
+    exchangeCode: exchangeCodeMock,
+    getCurrentUser: getCurrentUserMock,
+  },
 }));
 
 vi.mock('@/features/auth/useAuth', () => ({
@@ -35,14 +49,6 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-function jsonResponse(status: number, body: unknown): Response {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: () => Promise.resolve(body),
-  } as unknown as Response;
-}
-
 function renderCallback(search: string) {
   return render(
     <MemoryRouter initialEntries={[`/auth/callback${search}`]}>
@@ -53,16 +59,12 @@ function renderCallback(search: string) {
 
 describe('AuthCallback', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn());
     vi.clearAllMocks();
   });
 
   it('redeems the exchange code, stores the refresh token and authenticates the user', async () => {
-    vi.mocked(fetch)
-      .mockResolvedValueOnce(jsonResponse(200, { data: { accessToken: 'access-jwt', refreshToken: 'refresh-raw' } }))
-      .mockResolvedValueOnce(
-        jsonResponse(200, { data: { id: 'user-1', email: 'user@test.com', name: 'User', role: 'user' } }),
-      );
+    exchangeCodeMock.mockResolvedValueOnce({ accessToken: 'access-jwt', refreshToken: 'refresh-raw' });
+    getCurrentUserMock.mockResolvedValueOnce({ id: 'user-1', email: 'user@test.com', name: 'User', role: 'user' });
 
     renderCallback('?success=true&code=one-time-code');
 
@@ -70,10 +72,7 @@ describe('AuthCallback', () => {
       expect(navigateMock).toHaveBeenCalledWith('/', { replace: true });
     });
 
-    const exchangeCall = vi.mocked(fetch).mock.calls[0];
-    expect(String(exchangeCall[0])).toBe('http://test.api/auth/exchange');
-    expect(JSON.parse((exchangeCall[1] as RequestInit).body as string)).toEqual({ code: 'one-time-code' });
-
+    expect(exchangeCodeMock).toHaveBeenCalledWith('one-time-code');
     expect(localStorage.getItem('refresh_token')).toBe('refresh-raw');
     expect(setAuthMock).toHaveBeenCalledWith(
       { id: 'user-1', email: 'user@test.com', name: 'User', avatar: undefined, role: 'user' },
@@ -81,8 +80,24 @@ describe('AuthCallback', () => {
     );
   });
 
+  it('hands the access token to the API client before requesting the profile', async () => {
+    exchangeCodeMock.mockResolvedValueOnce({ accessToken: 'access-jwt', refreshToken: 'refresh-raw' });
+    getCurrentUserMock.mockResolvedValueOnce({ id: 'user-1', email: 'user@test.com', role: 'user' });
+
+    renderCallback('?success=true&code=one-time-code');
+
+    await waitFor(() => {
+      expect(getCurrentUserMock).toHaveBeenCalled();
+    });
+
+    expect(setAccessTokenMock).toHaveBeenCalledWith('access-jwt');
+    expect(setAccessTokenMock.mock.invocationCallOrder[0]).toBeLessThan(
+      getCurrentUserMock.mock.invocationCallOrder[0],
+    );
+  });
+
   it('navigates home unauthenticated when the exchange fails', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(401, { message: 'Invalid or expired exchange code' }));
+    exchangeCodeMock.mockRejectedValueOnce(new Error('Invalid or expired exchange code'));
 
     renderCallback('?success=true&code=stale-code');
 
@@ -91,7 +106,22 @@ describe('AuthCallback', () => {
     });
 
     expect(setAuthMock).not.toHaveBeenCalled();
+    expect(getCurrentUserMock).not.toHaveBeenCalled();
     expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
+  it('clears the access token when the profile request fails after a valid exchange', async () => {
+    exchangeCodeMock.mockResolvedValueOnce({ accessToken: 'access-jwt', refreshToken: 'refresh-raw' });
+    getCurrentUserMock.mockRejectedValueOnce(new Error('me failed'));
+
+    renderCallback('?success=true&code=one-time-code');
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/', { replace: true });
+    });
+
+    expect(setAuthMock).not.toHaveBeenCalled();
+    expect(setAccessTokenMock).toHaveBeenLastCalledWith(null);
   });
 
   it('navigates home without calling the API when no code is present', async () => {
@@ -101,12 +131,12 @@ describe('AuthCallback', () => {
       expect(navigateMock).toHaveBeenCalledWith('/', { replace: true });
     });
 
-    expect(fetch).not.toHaveBeenCalled();
+    expect(exchangeCodeMock).not.toHaveBeenCalled();
     expect(setAuthMock).not.toHaveBeenCalled();
   });
 
   it('renders the loading state while the exchange is in flight', () => {
-    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+    exchangeCodeMock.mockReturnValue(new Promise(() => {}));
 
     renderCallback('?success=true&code=one-time-code');
 

--- a/apps/frontend/src/pages/AuthCallback.tsx
+++ b/apps/frontend/src/pages/AuthCallback.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/features/auth/useAuth';
 import { isUserRole } from '@/features/auth/types';
 import { useI18nNamespacesReady } from '@/shared/hooks/useI18nNamespacesReady';
-import { ENV } from '@/config/env';
-import { REFRESH_TOKEN_KEY } from '@/api/client';
+import { REFRESH_TOKEN_KEY, setAccessToken } from '@/api/client';
+import { authApi } from '@/api/auth.api';
 
 const AUTH_NAMESPACES = ['auth'] as const;
 
@@ -28,30 +28,19 @@ export function AuthCallback() {
       return;
     }
 
-    async function bootstrap() {
+    async function bootstrap(oneTimeCode: string) {
       try {
         // Redeem the one-time exchange code for the token pair; the refresh
         // token itself never travels in the callback URL.
-        const exchangeRes = await fetch(`${ENV.API_URL}/auth/exchange`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ code }),
-        });
-        if (!exchangeRes.ok) throw new Error('exchange failed');
-        const exchangeBody = (await exchangeRes.json()) as { data?: { accessToken?: string; refreshToken?: string } };
-        const accessToken = exchangeBody.data?.accessToken;
-        const refreshToken = exchangeBody.data?.refreshToken;
+        const { accessToken, refreshToken } = await authApi.exchangeCode(oneTimeCode);
         if (!accessToken || !refreshToken) throw new Error('no tokens');
         localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
 
-        const meRes = await fetch(`${ENV.API_URL}/auth/me`, {
-          headers: { Authorization: `Bearer ${accessToken}` },
-        });
-        if (!meRes.ok) throw new Error('me failed');
-        const meBody = (await meRes.json()) as {
-          data?: { id: string; email: string; name?: string; avatar?: string; role: string };
-        };
-        const user = meBody.data;
+        // Hand the token to the API client before the next call, which reads it
+        // from there instead of taking it as an argument.
+        setAccessToken(accessToken);
+
+        const user = await authApi.getCurrentUser();
         if (user && isUserRole(user.role)) {
           setAuth(
             { id: user.id, email: user.email, name: user.name, avatar: user.avatar, role: user.role },
@@ -59,12 +48,14 @@ export function AuthCallback() {
           );
         }
       } catch {
-        // fall through to navigate home unauthenticated
+        // Fall through to navigate home unauthenticated, without leaving a
+        // half-established session behind in the API client.
+        setAccessToken(null);
       }
       navigate('/', { replace: true });
     }
 
-    void bootstrap();
+    void bootstrap(code);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.search, navigate]);
 


### PR DESCRIPTION
Closes #100

## Qué problema resuelve

Dos fixes de consistencia agrupados en la misma issue:

**(a) Backend.** `Transaction.amount` se declaraba `number` en TypeORM, pero una columna `decimal`
vuelve de Postgres como `string` en runtime sin un transformer que la convierta. El código defensivo
(`new Decimal(String(amount))`) tapaba el síntoma en el sitio donde ya se sabía del problema, pero
cualquier consumidor nuevo que confiara en el tipo declarado podía hacer aritmética sobre un string
sin que TypeScript avisara.

**(b) Frontend.** 4 llamadas `fetch` crudas en código de auth (`AuthContext.tsx`, `AuthCallback.tsx`)
esquivaban `apiRequest`, duplicando headers y parsing, con `/auth/me` implementado dos veces y la
config repartida entre `ENV.API_URL` (validado) y un `import.meta.env.VITE_API_URL || '/api'` a pelo.

## Cambios

**(a) Backend — `3d7e80b`**
- Column transformer en `Transaction.amount` para que el valor en runtime coincida con el tipo `number` declarado.
- Test que verifica el tipo real, no sólo el declarado.

**(b) Frontend — `30b1d62`**
- Nuevo módulo `src/api/auth.api.ts` (`exchangeCode`, `getCurrentUser`, `logout`, `oauthLoginUrl`), siguiendo el patrón del resto de `src/api/`.
- `apiRequest` gana la opción `skipAuthRefresh`, para los endpoints que son parte del propio ciclo de refresh (sin ella, `logout` borra el refresh token, recibe un 401, falla el refresh, emite `auth:logout` y se vuelve a llamar en bucle infinito).
- `logout` ahora lanza la petición **antes** de limpiar la sesión local — el cliente lee el token de su propio módulo, no de un argumento.
- `AuthCallback` entrega el token con `setAccessToken` antes de pedir el perfil.
- Toda la config de auth unificada en `ENV.API_URL`, eliminando el `import.meta.env.VITE_API_URL || '/api'` que quedaba en `AuthContext` y en los dos botones de login.
- Regla ESLint `no-restricted-globals` sobre `fetch` (con `src/api/client.ts` exceptuado), para que el criterio de aceptación se rompa solo ante una regresión futura.

## Cambio de contrato observable

> **Atención al revisar.** `GET /api/transactions/:id` y `GET /api/events/:id/transactions` ahora
> devuelven `amount` como número JSON (`21`) en lugar de string (`"21.00"`). El frontend ya lo
> declaraba como `number`, así que este cambio va a favor de obra, pero es un cambio visible en el
> contrato de la API — cualquier consumidor externo que dependiera del string se rompe.

También hay un cambio menor de comportamiento en el frontend: un fallo de red en `/auth/me` ahora
produce el error `network_error` en vez de propagar el mensaje crudo de `fetch`, y un 401 en
`/auth/me` intenta ahora un refresh transparente antes de dar la sesión por perdida (antes fallaba
directamente).

## Verificación

- `pnpm lint` — OK
- `pnpm -r build` — OK (único type-check real del monorepo)
- Backend: unit 233 / integration 39 / e2e 52 — OK
- Frontend: 240 tests (34 ficheros) — OK

Todas las validaciones se han ejecutado en local antes de abrir el PR.
