### PR TITLE
fix(backend): raise .env.example JWT_SECRET placeholder to the schema's 32-char minimum (#103)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -123,7 +123,7 @@ FRONTEND_URL=<frontend-url-with-hash-base>
 ### JWT and refresh tokens
 
 ```bash
-JWT_SECRET=<strong-secret>
+JWT_SECRET=<strong-secret>          # minimum 32 characters, or the backend refuses to boot
 JWT_EXPIRATION=15m
 REFRESH_TOKEN_EXPIRATION_DAYS=30
 REFRESH_TOKEN_MAX_ROTATIONS=100

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -23,9 +23,8 @@ TYPEORM_LOGGING=true
 # CORS
 CORS_ORIGIN=http://localhost:5173
 
-# JWT
-
-JWT_SECRET=replace-with-secure-random
+# JWT — envValidationSchema requires at least 32 characters.
+JWT_SECRET=replace-with-a-secure-random-string-min-32-chars
 JWT_EXPIRATION=15m
 REFRESH_TOKEN_EXPIRATION_DAYS=30
 # One-time OAuth callback exchange code lifetime (seconds)

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -167,8 +167,8 @@ TYPEORM_LOGGING=true
 # CORS
 CORS_ORIGIN=http://localhost:5173
 
-# JWT
-JWT_SECRET=replace-with-secure-random
+# JWT — envValidationSchema requires at least 32 characters.
+JWT_SECRET=replace-with-a-secure-random-string-min-32-chars
 JWT_EXPIRATION=15m
 REFRESH_TOKEN_EXPIRATION_DAYS=30
 

--- a/apps/backend/src/config/env.validation.spec.ts
+++ b/apps/backend/src/config/env.validation.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as dotenv from 'dotenv';
 import type { ValidationError } from 'joi';
 import { envValidationSchema } from './env.validation';
 import { DEFAULT_JWT_EXPIRATION } from './auth.constants';
@@ -39,6 +42,19 @@ describe('envValidationSchema', () => {
 
       expect(error).toBeUndefined();
       expect(value.JWT_EXPIRATION).toBe('30m');
+    });
+  });
+
+  // The example files are what a fresh clone copies into .env.development / .env.test, so a schema
+  // change that they do not follow makes the backend unbootable and the DB-backed suites unrunnable.
+  describe('example env files', () => {
+    it.each(['.env.example', '.env.test.example'])('%s satisfies the schema as-is', (fileName) => {
+      const parsed = dotenv.parse(readFileSync(join(__dirname, '..', '..', fileName)));
+
+      // allowUnknown: the examples may document variables the schema does not own.
+      const { error } = envValidationSchema.validate(parsed, { abortEarly: false, allowUnknown: true });
+
+      expect(error).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Closes #103

## Qué problema resuelve

El esquema Joi de `src/config/env.validation.ts:21` exige `JWT_SECRET: Joi.string().min(32).required()`, pero el placeholder de `.env.example` tenía 26 caracteres, así que `cp .env.example .env.development` + `pnpm dev:backend` abortaba con `Config validation error: "JWT_SECRET" length must be at least 32 characters long`.

La issue estaba resuelta a medias: `.env.test.example` ya se arregló en el PR #110 (commit 21aeab5), así que el impacto sobre las suites de integración y e2e que describía la issue ya no existía — el CI copia `.env.test.example`, no `.env.example`, y llevaba verde. Lo que quedaba era el arranque en desarrollo local.

## Cambios

| Fichero | Cambio |
|---|---|
| `apps/backend/.env.example` | Placeholder de `JWT_SECRET` a 48 caracteres (`replace-with-a-secure-random-string-min-32-chars`), claramente un placeholder, con la misma nota que ya llevaba `.env.test.example` |
| `apps/backend/README.md:170` | Tenía una tercera copia del mismo placeholder corto (documentación duplicada del bloque de `.env.example`); alineada con el fichero real |
| `DEPLOYMENT.md:126` | Nota del mínimo de 32 caracteres en el bloque JWT. `.github/SECURITY.md` §3 ya documenta la generación y ya está enlazado desde `DEPLOYMENT.md:156`, así que no se duplica |
| `apps/backend/src/config/env.validation.spec.ts` | Guard de regresión (suite unit, sin Postgres): parsea `.env.example` y `.env.test.example` con dotenv y los valida contra `envValidationSchema`. Cubre cualquier variable futura, no solo `JWT_SECRET` |

No se toca `CHANGELOG.md`: según `.claude/gh-project.md` se actualiza en el commit de bump.

## Fuera de alcance

Cambiar el `min(32)` del esquema, tal como dice la issue.

## Verificación

- `pnpm lint` — OK
- `pnpm -r build` — OK (único type-check real del monorepo)
- `pnpm --filter @friends/backend test:all` con `.env.test` copiado literal del ejemplo: 25 + 9 + 7 suites, 332 tests, todo verde
- Verificado que el guard de regresión falla con el placeholder viejo y pasa con el nuevo
