### PR TITLE
fix(frontend): allow decimal input on amount fields in Safari iOS (#138)

### DIFF
--- a/apps/frontend/src/features/events/components/ParticipantRow.test.tsx
+++ b/apps/frontend/src/features/events/components/ParticipantRow.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ParticipantRow } from './ParticipantRow';
+import type { EventParticipant } from '../types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/i18n', () => ({
+  getCurrentLocale: () => 'es-ES',
+}));
+
+vi.mock('./ParticipantsCombobox', () => ({
+  ParticipantsCombobox: () => <div data-testid="participants-combobox" />,
+}));
+
+const guest: EventParticipant = { type: 'guest', id: 'g1', name: 'Ana' };
+
+type ParticipantRowProps = Parameters<typeof ParticipantRow>[0];
+
+function makeProps(overrides: Partial<ParticipantRowProps> = {}): ParticipantRowProps {
+  return {
+    participant: guest,
+    participantIndex: 1,
+    isFirst: false,
+    existingParticipants: [guest],
+    isRenamingGuest: false,
+    isReplacingGuest: false,
+    renamingGuestName: '',
+    replaceInputValue: '',
+    onDelete: vi.fn(),
+    onStartReplace: vi.fn(),
+    onCancelReplace: vi.fn(),
+    onReplaceWithUser: vi.fn(),
+    onReplaceInputChange: vi.fn(),
+    onStartRename: vi.fn(),
+    onCancelRename: vi.fn(),
+    onRenameNameChange: vi.fn(),
+    onCommitRename: vi.fn(),
+    onTargetChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+function getTargetInput() {
+  return screen.getByLabelText('participantsInput.targetAria');
+}
+
+describe('ParticipantRow contribution target', () => {
+  // type=number is deliberately avoided: Safari on iOS reports an empty value for a half-typed
+  // decimal, which silently dropped what the user typed. See sanitizeAmountInput.
+  it('is a text field with a decimal keyboard', () => {
+    render(<ParticipantRow {...makeProps()} />);
+    expect(getTargetInput()).toHaveAttribute('type', 'text');
+    expect(getTargetInput()).toHaveAttribute('inputmode', 'decimal');
+  });
+
+  it('shows an empty field when there is no target', () => {
+    render(<ParticipantRow {...makeProps()} />);
+    expect(getTargetInput()).toHaveValue('');
+  });
+
+  it('shows the existing target', () => {
+    render(<ParticipantRow {...makeProps({ participant: { ...guest, contributionTarget: 25.5 } })} />);
+    expect(getTargetInput()).toHaveValue('25.5');
+  });
+
+  it('normalizes a comma typed as decimal separator', () => {
+    const onTargetChange = vi.fn();
+    render(<ParticipantRow {...makeProps({ onTargetChange })} />);
+
+    fireEvent.change(getTargetInput(), { target: { value: '10,99' } });
+
+    expect(onTargetChange).toHaveBeenCalledWith(10.99);
+    expect(getTargetInput()).toHaveValue('10.99');
+  });
+
+  it('keeps a half-typed decimal visible while the parent only sees the integer', () => {
+    const onTargetChange = vi.fn();
+    render(<ParticipantRow {...makeProps({ onTargetChange })} />);
+
+    fireEvent.change(getTargetInput(), { target: { value: '10,' } });
+
+    expect(onTargetChange).toHaveBeenCalledWith(10);
+    expect(getTargetInput()).toHaveValue('10.');
+  });
+
+  it('clears the target when the field is emptied', () => {
+    const onTargetChange = vi.fn();
+    render(<ParticipantRow {...makeProps({ participant: { ...guest, contributionTarget: 20 }, onTargetChange })} />);
+
+    fireEvent.change(getTargetInput(), { target: { value: '' } });
+
+    expect(onTargetChange).toHaveBeenCalledWith(undefined);
+    expect(getTargetInput()).toHaveValue('');
+  });
+
+  it('resyncs the field when the target changes from outside', () => {
+    const { rerender } = render(
+      <ParticipantRow {...makeProps({ participant: { ...guest, contributionTarget: 20 } })} />,
+    );
+    expect(getTargetInput()).toHaveValue('20');
+
+    rerender(<ParticipantRow {...makeProps({ participant: { ...guest, contributionTarget: 30 } })} />);
+
+    expect(getTargetInput()).toHaveValue('30');
+  });
+
+  it('does not render the target field for the pot participant', () => {
+    render(<ParticipantRow {...makeProps({ participant: { type: 'pot', id: '0' } })} />);
+    expect(screen.queryByLabelText('participantsInput.targetAria')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/features/events/components/ParticipantRow.tsx
+++ b/apps/frontend/src/features/events/components/ParticipantRow.tsx
@@ -1,11 +1,17 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { MdCheck, MdClose, MdDelete, MdEdit, MdSwapHoriz } from 'react-icons/md';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/shared/utils/cn';
+import { sanitizeAmountInput } from '@/shared/utils/format/sanitizeAmountInput';
 import { Avatar } from '@/shared/components/Avatar';
 import { ParticipantsCombobox } from './ParticipantsCombobox';
 import type { EventParticipant } from '../types';
 import { getParticipantAvatar, getParticipantName } from '../utils/participants';
+
+/** An unset target is stored as 0 but shown as an empty field. */
+function formatTargetDraft(target: number): string {
+  return target === 0 ? '' : String(target);
+}
 
 interface ParticipantRowProps {
   participant: EventParticipant;
@@ -54,6 +60,20 @@ export const ParticipantRow = memo(function ParticipantRow({
   const participantName = getParticipantName(participant, t);
   const participantEmail = participant.type === 'user' ? participant.email : undefined;
   const currentTarget = participant.type !== 'pot' ? (participant.contributionTarget ?? 0) : 0;
+
+  // The target field is text-based (see sanitizeAmountInput), so it owns its draft: a half-typed
+  // decimal such as '10.' has no numeric representation to render back from the participant.
+  const [targetDraft, setTargetDraft] = useState(() => formatTargetDraft(currentTarget));
+  const [lastExternalTarget, setLastExternalTarget] = useState(currentTarget);
+
+  if (currentTarget !== lastExternalTarget) {
+    setLastExternalTarget(currentTarget);
+
+    // Only overwrite the draft when the change did not come from this field.
+    if (parseFloat(targetDraft) !== currentTarget) {
+      setTargetDraft(formatTargetDraft(currentTarget));
+    }
+  }
 
   return (
     <div>
@@ -224,24 +244,16 @@ export const ParticipantRow = memo(function ParticipantRow({
             <div className="relative w-28">
               <input
                 id={`target-${participantIndex}`}
-                type="number"
-                min="0"
-                step="0.01"
-                value={currentTarget === 0 ? '' : currentTarget}
+                type="text"
+                inputMode="decimal"
+                autoComplete="off"
+                value={targetDraft}
                 onChange={(e) => {
-                  const val = e.target.value.trim();
-                  if (val === '') {
-                    onTargetChange(undefined);
-                    return;
-                  }
+                  const sanitized = sanitizeAmountInput(e.target.value);
+                  setTargetDraft(sanitized);
 
-                  const parsedValue = Math.round(Number(val) * 100) / 100;
-                  if (!Number.isFinite(parsedValue)) {
-                    onTargetChange(undefined);
-                    return;
-                  }
-
-                  onTargetChange(parsedValue < 0 ? 0 : parsedValue);
+                  const parsedValue = parseFloat(sanitized);
+                  onTargetChange(Number.isFinite(parsedValue) ? parsedValue : undefined);
                 }}
                 placeholder={t('participantsInput.targetPlaceholder')}
                 className={cn(

--- a/apps/frontend/src/features/transactions/components/TransactionForm.test.tsx
+++ b/apps/frontend/src/features/transactions/components/TransactionForm.test.tsx
@@ -44,19 +44,20 @@ describe('TransactionForm', () => {
     expect(screen.getByTestId('participant-combobox')).toBeInTheDocument();
   });
 
-  it('amount input has type=number, min=0.01 and step=0.01', () => {
+  // type=number is deliberately avoided: Safari on iOS reports an empty value for a half-typed
+  // decimal, which silently blocked the form. See sanitizeAmountInput.
+  it('amount input is a text field with a decimal keyboard', () => {
     render(<TransactionForm fields={makeFields()} participants={[]} onSubmit={vi.fn()} />);
     const amountInput = screen.getByLabelText('transactionForm.amountLabel');
-    expect(amountInput).toHaveAttribute('type', 'number');
-    expect(amountInput).toHaveAttribute('min', '0.01');
-    expect(amountInput).toHaveAttribute('step', '0.01');
+    expect(amountInput).toHaveAttribute('type', 'text');
+    expect(amountInput).toHaveAttribute('inputmode', 'decimal');
   });
 
   it('renders initial values from fields prop', () => {
     const fields = makeFields({ title: 'Dinner', amount: '25.50', date: '2026-01-15' });
     render(<TransactionForm fields={fields} participants={[]} onSubmit={vi.fn()} />);
     expect(screen.getByLabelText('transactionForm.titleLabel')).toHaveValue('Dinner');
-    expect(screen.getByLabelText('transactionForm.amountLabel')).toHaveValue(25.5);
+    expect(screen.getByLabelText('transactionForm.amountLabel')).toHaveValue('25.50');
     expect(screen.getByLabelText('transactionForm.dateLabel')).toHaveValue('2026-01-15');
   });
 
@@ -76,6 +77,33 @@ describe('TransactionForm', () => {
       target: { value: '10.99' },
     });
     expect(setAmount).toHaveBeenCalledWith('10.99');
+  });
+
+  it('normalizes a comma typed as decimal separator', () => {
+    const setAmount = vi.fn();
+    render(<TransactionForm fields={makeFields({ setAmount })} participants={[]} onSubmit={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('transactionForm.amountLabel'), {
+      target: { value: '10,99' },
+    });
+    expect(setAmount).toHaveBeenCalledWith('10.99');
+  });
+
+  it('keeps a half-typed decimal so the user can keep typing', () => {
+    const setAmount = vi.fn();
+    render(<TransactionForm fields={makeFields({ setAmount })} participants={[]} onSubmit={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('transactionForm.amountLabel'), {
+      target: { value: '10,' },
+    });
+    expect(setAmount).toHaveBeenCalledWith('10.');
+  });
+
+  it('drops characters that are not digits or separators', () => {
+    const setAmount = vi.fn();
+    render(<TransactionForm fields={makeFields({ setAmount })} participants={[]} onSubmit={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('transactionForm.amountLabel'), {
+      target: { value: '1o,99e' },
+    });
+    expect(setAmount).toHaveBeenCalledWith('1.99');
   });
 
   it('calls setDate when date input changes', () => {

--- a/apps/frontend/src/features/transactions/components/TransactionForm.tsx
+++ b/apps/frontend/src/features/transactions/components/TransactionForm.tsx
@@ -4,6 +4,7 @@ import type { EventParticipant } from '../../events/types';
 import { useTranslation } from 'react-i18next';
 import { FaRegCalendarAlt } from 'react-icons/fa';
 import { cn } from '@/shared/utils/cn';
+import { sanitizeAmountInput } from '@/shared/utils/format/sanitizeAmountInput';
 import { TransactionParticipantCombobox } from './TransactionParticipantCombobox';
 
 export interface TransactionFormState {
@@ -73,11 +74,11 @@ export function TransactionForm({ fields, participants, onSubmit }: TransactionF
               id="transaction-amount"
               className="w-full pl-5 pr-12 py-4 rounded-2xl border border-slate-200 dark:border-emerald-800 bg-slate-50/50 dark:bg-emerald-900/30 focus:ring-2 focus:ring-emerald-500 focus:border-transparent outline-none transition-all dark:text-white placeholder:text-slate-400 dark:placeholder:text-emerald-700 font-medium"
               placeholder="0,00"
-              type="number"
-              min="0.01"
-              step="0.01"
+              type="text"
+              inputMode="decimal"
+              autoComplete="off"
               value={amount}
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={(e) => setAmount(sanitizeAmountInput(e.target.value))}
             />
             <span aria-hidden className="absolute right-5 top-1/2 -translate-y-1/2 font-bold text-slate-400">
               €

--- a/apps/frontend/src/shared/utils/format/index.ts
+++ b/apps/frontend/src/shared/utils/format/index.ts
@@ -2,3 +2,4 @@ export * from './formatAmount';
 export * from './formatDateLong';
 export * from './formatDateShort';
 export * from './parseDateForFormatting';
+export * from './sanitizeAmountInput';

--- a/apps/frontend/src/shared/utils/format/sanitizeAmountInput.test.ts
+++ b/apps/frontend/src/shared/utils/format/sanitizeAmountInput.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeAmountInput } from './sanitizeAmountInput';
+
+/**
+ * Tests for the sanitizeAmountInput utility
+ * Used to keep money fields typeable on locales that use a comma as decimal separator
+ */
+describe('sanitizeAmountInput', () => {
+  it('should keep a plain integer untouched', () => {
+    expect(sanitizeAmountInput('25')).toBe('25');
+  });
+
+  it('should keep a well formed decimal untouched', () => {
+    expect(sanitizeAmountInput('25.50')).toBe('25.50');
+  });
+
+  it('should convert a comma into a decimal point', () => {
+    expect(sanitizeAmountInput('25,50')).toBe('25.50');
+  });
+
+  it('should preserve a trailing separator so the user can keep typing', () => {
+    expect(sanitizeAmountInput('25,')).toBe('25.');
+    expect(sanitizeAmountInput('25.')).toBe('25.');
+  });
+
+  it('should keep only the first separator', () => {
+    expect(sanitizeAmountInput('25.5.7')).toBe('25.57');
+    expect(sanitizeAmountInput('25,5,7')).toBe('25.57');
+  });
+
+  it('should truncate to two decimals', () => {
+    expect(sanitizeAmountInput('25.5678')).toBe('25.56');
+  });
+
+  it('should drop any character that is not a digit or a separator', () => {
+    expect(sanitizeAmountInput('25,50 €')).toBe('25.50');
+    expect(sanitizeAmountInput('-25')).toBe('25');
+    expect(sanitizeAmountInput('abc')).toBe('');
+  });
+
+  it('should allow a leading separator', () => {
+    expect(sanitizeAmountInput(',5')).toBe('.5');
+    expect(parseFloat(sanitizeAmountInput(',5'))).toBe(0.5);
+  });
+
+  it('should return an empty string for empty input', () => {
+    expect(sanitizeAmountInput('')).toBe('');
+  });
+});

--- a/apps/frontend/src/shared/utils/format/sanitizeAmountInput.ts
+++ b/apps/frontend/src/shared/utils/format/sanitizeAmountInput.ts
@@ -1,0 +1,23 @@
+const MAX_DECIMALS = 2;
+
+/**
+ * Normalizes raw text typed into a money field so it can be parsed with `parseFloat`.
+ *
+ * Money inputs cannot rely on `<input type="number">`: Safari on iOS parses the value with the
+ * system locale and reports an empty string while a decimal is half typed, so the React state and
+ * the text painted on screen drift apart and the form looks filled while it is not. Keeping the
+ * field as text and sanitizing here makes both platforms behave the same.
+ *
+ * Accepts either separator, keeps at most one decimal point and truncates to two decimals.
+ * Partial values such as `'12.'` are preserved so the user can keep typing.
+ */
+export function sanitizeAmountInput(rawValue: string): string {
+  const normalized = rawValue.replace(/,/g, '.').replace(/[^\d.]/g, '');
+  const [integerPart = '', ...decimalParts] = normalized.split('.');
+
+  if (decimalParts.length === 0) {
+    return integerPart;
+  }
+
+  return `${integerPart}.${decimalParts.join('').slice(0, MAX_DECIMALS)}`;
+}


### PR DESCRIPTION
Closes #138

## Qué problema resuelve

En Safari iOS, `input[type="number"]` devuelve una cadena vacía en `e.target.value` cuando el usuario está a mitad de teclear un decimal (por ejemplo, justo tras pulsar la coma o el punto). Eso vaciaba el estado de React del importe, y `canSubmit` (`!!amount.trim() && parseFloat(amount) > 0`) evaluaba a `false`, dejando el formulario bloqueado sin ningún mensaje de error. El mismo `type="number"` en el objetivo de contribución de `ParticipantRow` tenía el mismo defecto. En Chrome de escritorio no se reproducía porque su parser numérico se comporta distinto.

## Cambios

| Fichero | Cambio |
|---|---|
| `apps/frontend/src/shared/utils/format/sanitizeAmountInput.ts` (nuevo) | Helper puro: acepta coma o punto, conserva un único separador, trunca a 2 decimales, descarta el resto de caracteres y preserva valores a medio teclear (`'12.'`) |
| `apps/frontend/src/shared/utils/format/sanitizeAmountInput.test.ts` (nuevo) | 9 casos del helper |
| `apps/frontend/src/shared/utils/format/index.ts` | Exporta el helper en el barril |
| `apps/frontend/src/features/transactions/components/TransactionForm.tsx` | El importe pasa de `type="number"` a `type="text"` + `inputMode="decimal"` + `autoComplete="off"`, saneando en el `onChange` |
| `apps/frontend/src/features/transactions/components/TransactionForm.test.tsx` | Actualizado el test que asertaba `type=number`/`min`/`step`; añadidos casos de coma, decimal a medias y caracteres basura |
| `apps/frontend/src/features/events/components/ParticipantRow.tsx` | Mismo cambio en el objetivo de contribución; al ser el valor externo numérico, la fila mantiene ahora un draft de texto local que se re-sincroniza solo cuando el target cambia desde fuera |
| `apps/frontend/src/features/events/components/ParticipantRow.test.tsx` (nuevo) | 8 casos del campo de objetivo |

Los componentes importan el helper por ruta directa (`@/shared/utils/format/sanitizeAmountInput`), no por el barril `@/shared/utils`, porque ese barril arrastra `formatAmount` → `@/i18n` y rompe los tests que mockean `react-i18next` parcialmente — mismo patrón que `@/shared/utils/cn`.

## Verificación

- `pnpm check:skills` — verde
- `pnpm -r lint` — verde (backend + frontend)
- `pnpm test` — verde: frontend 265/265, backend unit 235/235 (con coverage)
- `pnpm build` — verde (monorepo completo: `shared-types`, backend, frontend)
- `format:check` **se ha omitido** de la validación estándar: falla sobre ~408 ficheros del repo (prácticamente todos, incluidos los no tocados por este PR) por un problema preexistente y ajeno a esta issue — `core.autocrlf=true` sin `.gitattributes` deja el working tree en CRLF en Windows mientras Prettier exige `endOfLine: "lf"`. Se verificó que el contenido indexado por git es LF (`git hash-object`), así que el commit es correcto en LF y CI (Linux) pasará `format:check` con normalidad. Se abre una issue aparte para añadir el `.gitattributes` que resuelve esto de raíz.
- Verificado manualmente por quien implementó el fix (fuera de este flujo automatizado).

Pendiente de comprobar: reproducción real en un dispositivo Safari iOS físico (lo cubierto aquí son los tests unitarios/component del comportamiento del input).